### PR TITLE
Bugfix for reality button

### DIFF
--- a/javascripts/components/reality/glyphs/reality-button.js
+++ b/javascripts/components/reality/glyphs/reality-button.js
@@ -16,7 +16,7 @@ Vue.component("reality-button", {
       return this.canReality ? "Make a new reality" : "Start reality over";
     },
     formatEPRequirement() {
-      return shorten(new Decimal('1e4000'), 0, 0);
+      return this.shorten("1e4000", 0, 0);
     },
     formatMachinesGained() {
       return `Machines gained: ${this.shorten(this.machinesGained, 2, 0)}`;
@@ -37,9 +37,9 @@ Vue.component("reality-button", {
   },
   methods: {
     update() {
-      if (!TimeStudy.reality.isBought || player.eternityPoints.lt("1e4000")) {
+      this.hasRealityStudy = TimeStudy.reality.isBought;
+      if (!this.hasRealityStudy || player.eternityPoints.lt("1e4000")) {
         this.canReality = false;
-        this.hasRealityStudy = TimeStudy.reality.isBought;
         this.shardsGained = 0;
         return;
       }


### PR DESCRIPTION
Specifically, pressing the reality button with less than e4000 EP now always starts reality over, and this is reflected in the display of the reality button. Previously pressing the reality button with less than e4000 EP but with dilation study 6 (the "unlock reality" study) bought would call `reality()`, which would fail since the `reality` function returns false immediately when EP is less than e4000. Another alternative behavior would be to allow realitying for 0 RM with less than e4000 EP (in which case we'd probably want a secret achievement for it). And yes, it is possible to have dilation study 6 with less than e4000 EP; get just a bit more than e4000 EP, buy dilation study 6, then buy max TD, TT, and 5x EP.

More generally, the good news is that I only plan to make PRs for clearly fixable bugs (probably all with this branch). The bad news is that when I make a PR, there's probably a bug.