### PR TITLE
fix display of free galaxy threshold multiplier upgrade

### DIFF
--- a/javascripts/core/secret-formula/eternity/dilation-upgrades.js
+++ b/javascripts/core/secret-formula/eternity/dilation-upgrades.js
@@ -31,7 +31,7 @@ GameDatabase.eternity.dilation = (function() {
         "Reset Dilated Galaxies, but lower their threshold" :
         "Reset Dilated Time and Dilated Galaxies, but lower their threshold",
       effect: bought => Math.pow(0.8, bought),
-      formatEffect: value => getFreeGalaxyMult().toFixed(3),
+      formatEffect: () => getFreeGalaxyMult().toFixed(3),
       formatCost: value => shorten(value, 1, 1)
     }),
     tachyonGain: rebuyable({


### PR DESCRIPTION
The current value in the button used to show the multiplier, now it does that again