### PR TITLE
reset free galaxies properly

### DIFF
--- a/javascripts/core/dilation.js
+++ b/javascripts/core/dilation.js
@@ -62,6 +62,7 @@ function buyDilationUpgrade(id) {
     if (id == 2) {
         if (!player.reality.perks.includes(11)) player.dilation.dilatedTime = new Decimal(0)
         player.dilation.nextThreshold = new Decimal(1000)
+        player.dilation.baseFreeGalaxies = 0
         player.dilation.freeGalaxies = 0
     }
 

--- a/javascripts/core/reality.js
+++ b/javascripts/core/reality.js
@@ -176,6 +176,7 @@ function reality(force, reset, auto) {
     player.dilation.totalTachyonParticles = new Decimal(0);
     player.dilation.nextThreshold = new Decimal(1000);
     player.dilation.baseFreeGalaxies = 0;
+    player.dilation.freeGalaxies = 0;
     player.dilation.upgrades = [];
     player.dilation.rebuyables = {
         1: 0,


### PR DESCRIPTION
Handles two cases: reality() (which was causing a bug where they'd stay for the first tick of a new reality) and buying d12, which previously could never decrease your free galaxies.