### PR TITLE
make dilation pow effect additive but uncapped

### DIFF
--- a/javascripts/core/glyph-effects.js
+++ b/javascripts/core/glyph-effects.js
@@ -8,7 +8,11 @@ const GLYPH_SYMBOLS = { time: "Δ", dilation: "Ψ", replication: "Ξ", infinity:
 const GlyphCombiner = Object.freeze({
   add: x => x.reduce(Number.sumReducer, 0),
   multiply: x => x.reduce(Number.prodReducer, 1),
-  addWithNullValueOne: x => x.reduce(Number.sumReducer, 1 - x.length),
+  // For exponents, the base value is 1, so when we add two exponents a and b we want to get a + b - 1,
+  // so that if a and b are both close to 1 so is their sum. In general, when we add a list x of exponents,
+  // we have to add 1 - x.length to the actual sum, so that if all the exponents are close to 1 the result
+  // is also close to 1 rather than close to x.length.
+  addExponents: x => x.reduce(Number.sumReducer, 1 - x.length),
 });
 
 /**
@@ -193,7 +197,7 @@ GameDatabase.reality.glyphEffects = [
     singleDesc: "Normal Dimension multipliers <br>^{value} while dilated",
     totalDesc: "Normal Dimension multipliers ^{value} while dilated",
     genericDesc: "Normal Dimensions ^x while dilated",
-    combine: GlyphCombiner.addWithNullValueOne,
+    combine: GlyphCombiner.addExponents,
   }, {
     id: "replicationspeed",
     glyphTypes: ["replication"],
@@ -206,7 +210,7 @@ GameDatabase.reality.glyphEffects = [
     id: "replicationpow",
     glyphTypes: ["replication"],
     singleDesc: "Replicanti multiplier ^{value}",
-    combine: GlyphCombiner.addWithNullValueOne,
+    combine: GlyphCombiner.addExponents,
   }, {
     id: "replicationdtgain",
     glyphTypes: ["replication"],


### PR DESCRIPTION
Use the same effect combiner as for replicantipow. This avoids an issue where dilation pow can stack to about 2000 and cause dilated runs to be better than undilated runs. When using 2 dilation glyphs, it's usually a boost, it might be a slight nerf for 3 or more but it probably won't affect the balance that much.