### PR TITLE
cap poured RM in save; fix dtBulk when loading old saves

### DIFF
--- a/javascripts/components/celestials/subtabs/teresa-tab.js
+++ b/javascripts/components/celestials/subtabs/teresa-tab.js
@@ -21,6 +21,7 @@ Vue.component('teresa-tab', {
   },
   computed: {
     unlockInfo: () => Teresa.unlockInfo,
+    rmStoreMax: () => Teresa.rmStoreMax,
   },
   methods: {
     update() {
@@ -93,7 +94,7 @@ Vue.component('teresa-tab', {
           >Pour RM</button>
           <div class="c-rm-store">
             <div class="c-rm-store-inner" :style="{ height: percentage}">
-              <div class="c-rm-store-label"> {{ shortenRateOfChange(rmMult) }}x RM gain<br>{{ shortenRateOfChange(rmStore) }}/{{ shortenRateOfChange(1e24) }}</div>
+              <div class="c-rm-store-label"> {{ shortenRateOfChange(rmMult) }}x RM gain<br>{{ shortenRateOfChange(rmStore) }}/{{ shortenRateOfChange(rmStoreMax) }}</div>
             </div>
             <div v-for="unlockInfo in unlockInfo" class="c-teresa-unlock-description" :style="unlockDescriptionStyle(unlockInfo)" :id="unlockInfo.id">
               {{ shortenRateOfChange(unlockInfo.price) }}: {{ unlockInfo.description }}

--- a/javascripts/core/celestials/teresa.js
+++ b/javascripts/core/celestials/teresa.js
@@ -38,12 +38,13 @@ var Teresa = {
   timePoured: 0,
   unlockInfo: TERESA_UNLOCKS,
   lastUnlock: "SHOP",
+  rmStoreMax: 1e24,
   pourRM(diff) {
-    if (this.rmstore >= 1e24) return
+    if (this.rmstore >= Teresa.rmStoreMax) return
     this.timePoured += diff
     let rm = player.reality.realityMachines;
     let rmPoured = Math.min((this.rmStore + 1e6) * 0.01 * Math.pow(this.timePoured, 2), rm.toNumber())
-    this.rmStore += Math.min(rmPoured, 1e24 - this.rmStore)
+    this.rmStore += Math.min(rmPoured, Teresa.rmStoreMax - this.rmStore)
     player.reality.realityMachines = rm.minus(rmPoured)
     this.checkForUnlocks()
   },

--- a/javascripts/core/devtools.js
+++ b/javascripts/core/devtools.js
@@ -509,6 +509,7 @@ dev.updateTestSave = function() {
     movePropIfPossible("effarig", "teresa", "rmStore", 0, Math.max);
     movePropIfPossible("effarig", "teresa", "glyphLevelMult", 1, Math.max);
     movePropIfPossible("effarig", "teresa", "rmMult", 1, Math.max);
+    movePropIfPossible("effarig", "teresa", "dtBulk", 1, Math.max);
     // These are unused now
     delete player.celestials.effarig.typePriorityOrder;
     delete player.celestials.teresa.typePriorityOrder;
@@ -526,7 +527,11 @@ dev.updateTestSave = function() {
   if (player.blackHole[0].unlocked) giveAchievement("Is this an Interstellar reference?")
   if (player.reality.perks.length === Perk.all.length) giveAchievement("Perks of living")
   if (player.reality.upg.length == REALITY_UPGRADE_COSTS.length - 6) giveAchievement("Master of Reality") // Rebuyables and that one null value = 6
-
+  if (player.celestials.teresa.rmStore > Teresa.rmStoreMax) {
+    player.reality.realityMachines =
+      player.reality.realityMachines.plus(player.celestials.teresa.rmStore - Teresa.rmStoreMax);
+    player.celestials.teresa.rmStore = Teresa.rmStoreMax;
+  }
 }
 
 // Still WIP


### PR DESCRIPTION
If poured RM is greater than max, refund RM and set it to max

Make the max poured RM a constant