### PR TITLE
Glyph level nerf at 5000

### DIFF
--- a/javascripts/core/rm.js
+++ b/javascripts/core/rm.js
@@ -706,13 +706,14 @@ function getGlyphLevelInputs() {
   var baseLevel = epEffect * replEffect * dtEffect * eterEffect * player.celestials.teresa.glyphLevelMult * Ra.glyphMult;
   var scaledLevel = baseLevel;
   // With begin = 1000 and rate = 250, a base level of 2000 turns into 1500; 4000 into 2000
-  const instabilityScaleBegin = 1000 + getAdjustedGlyphEffect("effarigglyph");
+  const scaleDelay = getAdjustedGlyphEffect("effarigglyph");
+  const instabilityScaleBegin = 1000 + scaleDelay;
   const instabilityScaleRate = 500;
   if (scaledLevel > instabilityScaleBegin) {
     const excess = (scaledLevel - instabilityScaleBegin) / instabilityScaleRate;
     scaledLevel = instabilityScaleBegin + 0.5 * instabilityScaleRate * (Math.sqrt(1 + 4 * excess) - 1);
   }
-  const hyperInstabilityScaleBegin = 3000 + getAdjustedGlyphEffect("effarigglyph");
+  const hyperInstabilityScaleBegin = 4000 + scaleDelay;
   const hyperInstabilityScaleRate = 1000;
   if (scaledLevel > hyperInstabilityScaleBegin) {
     const excess = (scaledLevel - hyperInstabilityScaleBegin) / hyperInstabilityScaleRate;


### PR DESCRIPTION
This branch nerfs glyph level at 5000, with our usual trusty sqrt nerf, already known from instability. Since 5000 is bigger than 1000, I somewhat arbitrarily chose nerf factor 1000 rather than 500. I'm not completely convinced that this nerf is strong enough, and I'm also not convinced that it's weak enough. Also instability isn't red after 5000; I tried to do that and it didn't work for some reason, so I'm sort of leaving it to someone better at Vue and CSS (I might try again though).

The only reason to accept this now would be if we wanted master to not explode at about 1e80 RM, but I'm not sure how urgent that is.