### PR TITLE
add will to the right place, remove it from the wrong one

### DIFF
--- a/javascripts/components/celestials/subtabs/effarig/effarig-tab.js
+++ b/javascripts/components/celestials/subtabs/effarig/effarig-tab.js
@@ -100,7 +100,7 @@ Vue.component('effarig-tab', {
     `<div class="l-effarig-celestial-tab">
       <div class="o-teresa-quotes"> {{ quote }}</div><button class="o-quote-button" @click="nextQuote()" v-if="hasNextQuote()">→</button>
       <div class="c-effarig-relics">You have {{ shortenRateOfChange(relicShards) }} Relic Shards.</div>
-      <div class="c-effarig-relic-description">You gain {{ shortenRateOfChange(shardsGained) }} Shards next reality, based on different kinds of glyph effects you have equipped and EP.</div>
+      <div class="c-effarig-relic-description">You will gain {{ shortenRateOfChange(shardsGained) }} Shards next reality, based on different kinds of glyph effects you have equipped and EP.</div>
       <div class="l-effarig-shop-and-run">
         <div class="l-effarig-shop">
           <effarig-unlock-button

--- a/javascripts/components/celestials/subtabs/teresa-tab.js
+++ b/javascripts/components/celestials/subtabs/teresa-tab.js
@@ -75,7 +75,7 @@ Vue.component('teresa-tab', {
       <div class="l-mechanics-container">
         <div class="l-teresa-unlocks l-teresa-mechanic-container">
           <div class="c-teresa-unlock c-teresa-run-button" v-if="unlocks[0]" @click="startRun()">Start a new reality. TT generation is disabled and you gain less IP and EP (x^0.6). The further you get the better the reward.<br><br>Multiplies power gained from glyph sacrifice by {{ shortenRateOfChange(runReward) }}x, based on realities.</div>
-          <div class="c-teresa-unlock" v-if="unlocks[1]">You will gain 1% of your peaked EP/min every second.</div>
+          <div class="c-teresa-unlock" v-if="unlocks[1]">You gain 1% of your peaked EP/min every second.</div>
           <div class="c-teresa-unlock" v-if="unlocks[2]">The container no longer leaks.</div>
           <div class="c-teresa-shop" v-if="unlocks[3]">
             <span class="o-teresa-pp"> You have {{ shorten(pp, 2, 2) }} Perk Points.</span>


### PR DESCRIPTION
Actually fixes #215 . Razen seems to have added "will" to the "gain 1% of EP per second", which doesn't seem necessary to me (since once you unlock the 1% of EP per second Teresa reward, you are gaining that). If I read #215 correctly, it wanted "will" to be added to the relic shard gain description.