### PR TITLE
add some parentheses, so that 324 becomes 324pL rather than 324.00

### DIFF
--- a/javascripts/core/notations.js
+++ b/javascripts/core/notations.js
@@ -606,7 +606,7 @@ Notation.imperial = new class ImperialNotation extends Notation {
     // The jump from metric to minim is sudden. Small values (< 10) get more decimal places
     // because that's usually something like sacrifice multiplier
     if (x < 1000) {
-      return x < 10 || x === Math.round(x) ? x.toFixed(2) : x.toFixed(0) + "pL"
+      return ((x < 10 || x === Math.round(x)) ? x.toFixed(2) : x.toFixed(0)) + "pL"
     }
     if (x < 1e6) return (x / 1000).toPrecision(4) + "nL";
     return (x / 1e6).toPrecision(4) + "μL";


### PR DESCRIPTION
Basically just the description. I added two sets of parentheses; one of them definitely changes the behavior to be what seems correct (if 323.99 becomes 324pL, then it seems that 324 should also become 324pL), and one of them probably doesn't change the behavior but was added for clarity.