### PR TITLE
Add countWhere to lists.

### DIFF
--- a/javascripts/core/extensions.js
+++ b/javascripts/core/extensions.js
@@ -186,13 +186,13 @@ Array.prototype.max = function() {
  * @param {function} predicate
  * @returns {number}
  */
-Array.prototype.countWhere = function (predicate) {
+Array.prototype.countWhere = function(predicate) {
   let count = 0;
-  for (let item of this) {
+  for (const item of this) {
     if (predicate(item))++count;
   }
   return count;
-}
+};
 
 /**
  * @returns {Decimal}
@@ -230,9 +230,9 @@ Array.prototype.randomElement = function() {
 
 Decimal.prototype.valueOf = () => { throw crash("Implicit conversion from Decimal to number"); };
 
-Set.prototype.countWhere = function (predicate) {
+Set.prototype.countWhere = function(predicate) {
   let count = 0;
-  for (let item of this) {
+  for (const item of this) {
     if (predicate(item))++count;
   }
   return count;


### PR DESCRIPTION
Fixes a bug where countWhere is called on lists and due to an error realitying doesn't actually reset anything.