### PR TITLE
add extra precision to reality upgrade costs

### DIFF
--- a/javascripts/core/secret-formula/eternity/dilation-upgrades.js
+++ b/javascripts/core/secret-formula/eternity/dilation-upgrades.js
@@ -20,7 +20,8 @@ GameDatabase.eternity.dilation = (function() {
       increment: 10,
       description: "Double Dilated Time gain.",
       effect: bought => Math.pow(2, bought),
-      formatEffect: value => formatX(value, 2, 0)
+      formatEffect: value => formatX(value, 2, 0),
+      formatCost: value => shorten(value, 2, 0)
     }),
     galaxyThreshold: rebuyable({
       id: 2,
@@ -32,7 +33,7 @@ GameDatabase.eternity.dilation = (function() {
         "Reset Dilated Time and Dilated Galaxies, but lower their threshold",
       effect: bought => Math.pow(0.8, bought),
       formatEffect: () => getFreeGalaxyMult().toFixed(3),
-      formatCost: value => shorten(value, 1, 1)
+      formatCost: value => shorten(value, 2, 0)
     }),
     tachyonGain: rebuyable({
       id: 3,
@@ -40,7 +41,8 @@ GameDatabase.eternity.dilation = (function() {
       increment: 20,
       description: "Triple the amount of Tachyon Particles gained.",
       effect: bought => Decimal.pow(3, bought),
-      formatEffect: value => formatX(value, 2, 0)
+      formatEffect: value => formatX(value, 2, 0),
+      formatCost: value => shorten(value, 2, 0)
     }),
     doubleGalaxies: {
       id: 4,

--- a/javascripts/core/secret-formula/reality/reality-upgrades.js
+++ b/javascripts/core/secret-formula/reality/reality-upgrades.js
@@ -10,6 +10,7 @@ GameDatabase.reality.upgrades = (function() {
     const { effect } = props;
     props.effect = () => Math.pow(effect, player.reality.rebuyables[props.id]);
     props.formatEffect = value => formatX(value, 2, 2);
+    props.formatCost = value => shorten(value, 2, 0);
     return props;
   };
   const isFirstEternity = () => player.realities > 0 && Player.gainedEternities === 0;
@@ -146,14 +147,16 @@ GameDatabase.reality.upgrades = (function() {
       requirement: "Reality with 4 glyphs with uncommon or better rarity",
       checkRequirement: () => Glyphs.activeList.countWhere(g => g.strength >= 1.5) === 4,
       description: "Improve the glyph rarity formula",
-      effect: () => 1.3
+      effect: () => 1.3,
+      formatCost: value => shorten(value, 1, 0)
     },
     {
       id: 17,
       cost: 1500,
       requirement: "Reality with 4 glyphs, with each having at least 2 effects",
       checkRequirement: () => Glyphs.activeList.countWhere(g => Object.keys(g.effects).length >= 2) === 4,
-      description: "50% chance to get +1 effect on glyphs"
+      description: "50% chance to get +1 effect on glyphs",
+      formatCost: value => shorten(value, 1, 0)
     },
     {
       id: 18,
@@ -161,21 +164,24 @@ GameDatabase.reality.upgrades = (function() {
       requirement: "Reality with 4 level 10 or higher glyphs equipped.",
       checkRequirement: () => Glyphs.activeList.countWhere(g => g.level >= 10) === 4,
       description: "Eternities affect glyph level",
-      effect: () => Math.max(Math.sqrt(Math.log10(player.eternities)) * 0.45, 1)
+      effect: () => Math.max(Math.sqrt(Math.log10(player.eternities)) * 0.45, 1),
+      formatCost: value => shorten(value, 1, 0)
     },
     {
       id: 19,
       cost: 1500,
       requirement: "Have a total of 30 or more glyphs",
       checkRequirement: () => Glyphs.active.concat(Glyphs.inventory).countWhere(g => g) >= 30,
-      description: "You can sacrifice glyphs for permanent bonuses (Shift + click)"
+      description: "You can sacrifice glyphs for permanent bonuses (Shift + click)",
+      formatCost: value => shorten(value, 1, 0)
     },
     {
       id: 20,
       cost: 1500,
       requirement: "2 years total play time",
       checkRequirement: () => Time.totalTimePlayed.totalYears >= 2,
-      description: "You can have 2 black holes"
+      description: "You can have 2 black holes",
+      formatCost: value => shorten(value, 1, 0)
     },
     {
       id: 21,


### PR DESCRIPTION
Add extra precision to reality upgrade costs (2 digits for rebuyables, 1 digit for 4th row (1.5e3)). Also add 2 digits of precision to all dilation upgrade costs (including d11 and d12, for uniformity). Fixes #402.