### PR TITLE
Make secret achievements hidden if they haven't been unlocked

### DIFF
--- a/javascripts/components/achievements/secret/secret-achievement.js
+++ b/javascripts/components/achievements/secret/secret-achievement.js
@@ -16,9 +16,12 @@ Vue.component("secret-achievement", {
       return SecretAchievement(this.achId);
     },
     styleObject() {
-      return {
-        "background-image": `url(images/s${this.achId}.png)`,
-      };
+      if (this.isUnlocked) {
+        return {
+          "background-image": `url(images/s${this.achId}.png)`,
+        };
+      }
+      return {};
     },
     classObject() {
       return {


### PR DESCRIPTION
Change the styleObject() of the secret achievements to not have a background image unless they're unlocked.