### PR TITLE
Make the "you have played for" time be based on absolute start time

### DIFF
--- a/javascripts/components/statistics/statistics-tab.js
+++ b/javascripts/components/statistics/statistics-tab.js
@@ -38,7 +38,7 @@ Vue.component("statistics-tab", {
       this.totalAntimatter.copyFrom(player.totalmoney);
       this.resets = player.resets;
       this.galaxies = Math.round(player.galaxies);
-      this.realTimePlayed.setFrom(player.realTimePlayed);
+      this.realTimePlayed.setFrom(Date.now() - player.gameCreatedTime);
       const progress = PlayerProgress.current;
       const isInfinityUnlocked = progress.isInfinityUnlocked;
       const infinity = this.infinity;

--- a/javascripts/core/devtools.js
+++ b/javascripts/core/devtools.js
@@ -548,6 +548,11 @@ dev.updateTestSave = function() {
     player.options.testVersion = 32;
   }
 
+  if (player.options.testVersion === 32) {
+    player.gameCreatedTime = Date.now() - player.realTimePlayed;
+    player.options.testVersion = 33;
+  }
+
   // Checks for presense of property, so no need for a version bump
   convertEPMult();
 

--- a/javascripts/core/load_functions.js
+++ b/javascripts/core/load_functions.js
@@ -169,6 +169,7 @@ function onLoad() {
     delete player.achPow;
     player.options.confirmations.sacrifice = player.options.sacrificeConfirmation;
     delete player.options.sacrificeConfirmation;
+    player.gameCreatedTime = Date.now() - player.realTimePlayed;
   }
 
   //TODO: REMOVE THE FOLLOWING LINE BEFORE RELEASE/MERGE FROM TEST (although it won't really do anything?)

--- a/javascripts/core/player.js
+++ b/javascripts/core/player.js
@@ -52,6 +52,7 @@ var player = {
   infinityPoints: new Decimal(0),
   infinitied: new Decimal(0),
   infinitiedBank: new Decimal(0),
+  gameCreatedTime: Date.now(),
   totalTimePlayed: 0,
   realTimePlayed: 0,
   bestInfinityTime: 999999999999,


### PR DESCRIPTION
This makes sure that stored real time (offline time) doesn't change this statistic.

Other things still use "real time" to mean the added up time of offline production.

Fixed #464