### PR TITLE
invalidate black hole upgrade lazy data on purchase

### DIFF
--- a/javascripts/core/black_hole.js
+++ b/javascripts/core/black_hole.js
@@ -22,9 +22,9 @@ class BlackHoleUpgradeState {
     if (!this.isAffordable) return;
     player.reality.realityMachines = player.reality.realityMachines.minus(this.cost);
     this.incrementAmount();
-    EventHub.dispatch(GameEvent.BLACK_HOLE_UPGRADE_BOUGHT);
     this._lazyValue.invalidate();
     this._lazyCost.invalidate();
+    EventHub.dispatch(GameEvent.BLACK_HOLE_UPGRADE_BOUGHT);
   }
 }
 


### PR DESCRIPTION
Not invalidating this was causing black hole upgrades to not change cost or (I think) take effect until you reloaded.