### PR TITLE
Make the game not switch tabs due to automator

### DIFF
--- a/javascripts/core/automator.js
+++ b/javascripts/core/automator.js
@@ -126,9 +126,7 @@ function mainIteration() {
         break;
       case "eternity":
         if (!player.reality.automatorCommands.has(62)) return false
-        justImported = true;
         if (eternity(false, true) || cont) automatorIdx+=1
-        justImported = false;
         break;
       case "stop":
         if (!player.reality.automatorCommands.has(72)) return false
@@ -163,13 +161,13 @@ function mainIteration() {
 }
 
 function buy(current) {
-  switch(current.target) {
+  let id;
+  switch (current.target) {
     case "study":
       id = parseInt(current.id)
       if (TimeStudy(id).isBought) return true;
       if (TimeStudy(id).purchase()) return true;
       return false;
-      break;
       case "studyuntil":
           id = parseInt(current.id);
           if (!TimeStudy(id).isBought) {
@@ -179,12 +177,12 @@ function buy(current) {
           break;
       case "studypath":
           if (!player.reality.automatorCommands.has(26)) return false;
-          studyPath(current.id, current.args);
+          studyPath(current.id, current.args, true);
           return true;
           break;
       case "studyimport":
           if (!player.reality.automatorCommands.has(36)) return false;
-          importStudyTree(current.id);
+          importStudyTree(current.id, true);
           return true;
           break;
     case "ttmax":
@@ -243,13 +241,7 @@ function unlock(current) {
     case "ec":
       if (!player.reality.automatorCommands.has(64)) return false
       if (player.challenge.eternity.unlocked === parseInt(current.id, 10)) return true;
-      justImported = true;
-      if (TimeStudy.eternityChallenge(current.id).purchase()) {
-        justImported = false;
-        return true;
-      }
-      else return false
-      break;
+      return TimeStudy.eternityChallenge(current.id).purchase(true);
     case "dilation":
       if (!player.reality.automatorCommands.has(63)) return false
       if (TimeStudy.dilation.purchase(true)) return true;

--- a/javascripts/core/eternity.js
+++ b/javascripts/core/eternity.js
@@ -35,7 +35,7 @@ function eternity(force, auto, switchingDilation) {
       }
     }
     player.etercreq = 0;
-    respecTimeStudies();
+    respecTimeStudies(auto);
   }
 
   player.infinitiedBank = player.infinitiedBank.plusEffectsOf(
@@ -65,7 +65,7 @@ function eternity(force, auto, switchingDilation) {
   resetChallengeStuff();
   resetDimensions();
 
-  if (player.respec) respecTimeStudies();
+  if (player.respec) respecTimeStudies(auto);
   player.respec = false;
   if (player.eternities === 1 || (player.reality.rebuyables[3] > 0 && player.eternities === RealityUpgrade(3).effectValue && player.eternityPoints.lte(10))) {
     Tab.dimensions.time.show();

--- a/javascripts/core/player.js
+++ b/javascripts/core/player.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var shiftDown = false;
-var justImported = false;
 var saved = 0;
 const defaultMaxTime = 60000 * 60 * 24 * 31;
 

--- a/javascripts/core/timestudies.js
+++ b/javascripts/core/timestudies.js
@@ -243,7 +243,7 @@ function studiesUntil(id) {
   }
 }
 
-function studyPath(mode, args) {
+function studyPath(mode, args, auto) {
     if (!(mode === 'none' || mode === 'all')) return false;
     if (args === undefined) args = [];
     args = args.map(function (x) { if (!isNaN(x)) return parseInt(x); else return x; });
@@ -354,11 +354,11 @@ function studyPath(mode, args) {
     }, '');
     string = string.slice(0, -1);
     string += '|0';
-    importStudyTree(string);
+    importStudyTree(string, auto);
 }
 
 
-function respecTimeStudies() {
+function respecTimeStudies(auto) {
   for (const study of TimeStudy.boughtNormalTS()) {
     study.refund();
   }
@@ -373,7 +373,7 @@ function respecTimeStudies() {
     ecStudy.refund();
     player.challenge.eternity.unlocked = 0;
   }
-  if (!justImported) {
+  if (!auto) {
     Tab.eternity.timeStudies.show();
   }
 }
@@ -386,7 +386,7 @@ function exportStudyTree() {
   copyToClipboardAndNotify(studyTreeExportString());
 }
 
-function importStudyTree(input) {
+function importStudyTree(input, auto) {
   const splitOnEC = input.split("|");
   splitOnEC[0].split(",")
     .map(id => parseInt(id, 10))
@@ -398,11 +398,7 @@ function importStudyTree(input) {
   if (splitOnEC.length === 2) {
     const ecNumber = parseInt(splitOnEC[1], 10);
     if (ecNumber !== 0 && !isNaN(ecNumber)) {
-      justImported = true;
-      TimeStudy.eternityChallenge(ecNumber).purchase();
-      setTimeout(() => {
-        justImported = false;
-      }, 100);
+      TimeStudy.eternityChallenge(ecNumber).purchase(auto);
     }
   }
 }
@@ -516,9 +512,9 @@ class ECTimeStudyState extends TimeStudyState {
     return player.challenge.eternity.unlocked === this.id;
   }
 
-  purchase() {
+  purchase(auto) {
     if (!this.canBeBought) return false;
-    unlockEChall(this.id);
+    unlockEChall(this.id, auto);
     player.timestudy.theorem = player.timestudy.theorem.minus(this.cost);
     return true;
   }

--- a/javascripts/game.js
+++ b/javascripts/game.js
@@ -355,10 +355,10 @@ function exitChallenge() {
   }
 }
 
-function unlockEChall(idx) {
+function unlockEChall(idx, auto) {
   if (player.challenge.eternity.unlocked === 0) {
     player.challenge.eternity.unlocked = idx;
-    if (!justImported) {
+    if (!auto) {
       Tab.challenges.eternity.show();
     }
     if (idx !== 12 && idx !== 13) player.etercreq = idx;


### PR DESCRIPTION
The current attempt on master to stop things like unlocking ECs to switch tabs when done by the automator uses a single global variable, justImported, and in fact for some unclear reason has a setTimeout call on it. This PR replaces that global variable by a function parameter auto that is explicitly passed where it's needed.