### PR TITLE
Show galaxy total in the AG row

### DIFF
--- a/javascripts/components/dimensions/normal/normal-dim-galaxy-row.js
+++ b/javascripts/components/dimensions/normal/normal-dim-galaxy-row.js
@@ -31,7 +31,11 @@ Vue.component("normal-dim-galaxy-row", {
       const parts = [this.galaxies.normal];
       if (this.galaxies.replicanti > 0) parts.push(this.galaxies.replicanti);
       if (this.galaxies.dilation > 0) parts.push(this.galaxies.dilation);
-      return parts.map(shortenSmallInteger).join(" + ");
+      const sum = parts.map(shortenSmallInteger).join(" + ");
+      if (parts.length >= 2) {
+        return `${sum} = ${parts.sum()}`;
+      }
+      return sum;
     },
     typeName() {
       switch (this.type) {

--- a/javascripts/components/new-ui/dimensions-tab/new-galaxy-row.js
+++ b/javascripts/components/new-ui/dimensions-tab/new-galaxy-row.js
@@ -31,7 +31,11 @@ Vue.component('new-galaxy-row', {
       const parts = [this.galaxies.normal];
       if (this.galaxies.replicanti > 0) parts.push(this.galaxies.replicanti);
       if (this.galaxies.dilation > 0) parts.push(this.galaxies.dilation);
-      return parts.map(shortenSmallInteger).join(" + ");
+      const sum = parts.map(shortenSmallInteger).join(" + ");
+      if (parts.length >= 2) {
+        return `${sum} = ${parts.sum()}`;
+      }
+      return sum;
     },
     typeName() {
       switch (this.type) {


### PR DESCRIPTION
This serves two purposes: letting the player see how close they are to RUpg51 and Anti-Stellar (both of which have total galaxy requirements), and satisfying the curiosity of people who want to know their total number of galaxies, but not enough to do a sum. We could have a tooltip instead, but ~~I'm too lazy for that~~ that seems harder for players to access.