### PR TITLE
Yet another td rebalance attempt

### DIFF
--- a/javascripts/components/celestials/subtabs/enslaved-tab.js
+++ b/javascripts/components/celestials/subtabs/enslaved-tab.js
@@ -130,7 +130,9 @@ Vue.component("enslaved-tab", {
           <p>Time theorem generation from dilation glyphs is much slower</p>
           <p>Certain challenge goals have been increased</p>
           <p>Stored time is much less effective</p>
-          <p>Reward: ID purchase caps are increased by 1000 for every 1000 free tickspeed upgrades you get</p>
+          <p>Rewards:</p>
+          <p>Free tickspeed upgrade softcap is 100000 higher</p>
+          <p>ID purchase caps are increased by 1000 for every 1000 free tickspeed upgrades you get</p>
         </button>
         </div>
     </div>`

--- a/javascripts/core/tickspeed.js
+++ b/javascripts/core/tickspeed.js
@@ -185,7 +185,7 @@ const Tickspeed = {
 
 
 const FreeTickspeed = {
-  SOFTCAP: 400000,
+  SOFTCAP: 300000,
   GROWTH_RATE: 4e-3,
   GROWTH_EXP: 1.5,
 
@@ -209,14 +209,18 @@ const FreeTickspeed = {
         nextShards: Decimal.pow(tickmult, Math.ceil(uncapped))
       };
     }
-    // Log of (cost - cost up to SOFTCAP)
-    const priceToCap = FreeTickspeed.SOFTCAP * logTickmult;
+    let softcap = FreeTickspeed.SOFTCAP;
+    if (Enslaved.isCompleted) {
+      softcap += 100000;
+    }
+    // Log of (cost - cost up to softcap)
+    const priceToCap = softcap * logTickmult;
     // In the following we're implicitly applying the function (ln(x) - priceToCap) / logTickmult to all costs,
     // so, for example, if the cost is 1 that means it's actually exp(priceToCap) * tickmult.
     const desiredCost = (logShards - priceToCap) / logTickmult;
     const costFormulaCoefficient = FreeTickspeed.GROWTH_RATE / FreeTickspeed.GROWTH_EXP / logTickmult;
-    // In the following we're implicitly subtracting FreeTickspeed.SOFTCAP from bought,
-    // so, for example, if bought is 1 that means it's actually FreeTickspeed.SOFTCAP + 1.
+    // In the following we're implicitly subtracting softcap from bought,
+    // so, for example, if bought is 1 that means it's actually softcap + 1.
     // The first term (the big one) is the asymptotically more important term (since FreeTickspeed.GROWTH_EXP > 1),
     // but is small initially. The second term allows us to continue the pre-cap free tickspeed upgrade scaling
     // of tickmult per upgrade.
@@ -236,7 +240,7 @@ const FreeTickspeed = {
     // the cost of the next upgrade.
     const next = Decimal.exp(priceToCap + boughtToCost(purchases + 1) * logTickmult);
     return {
-      newAmount: purchases + FreeTickspeed.SOFTCAP,
+      newAmount: purchases + softcap,
       nextShards: next,
     };
   }


### PR DESCRIPTION
In current master Teresa progress is far too quick, largely due to the 100k free tickspeed upgrades. This change seems to fix that by pushing the 100k free tickspeed upgrades out until Enslaved completion. One might think that it's too much of a nerf, and it might be eventually, but pre-Teresa-reality it seems fine, and I think it has a much better chance of working than current master does.