### PR TITLE
make sacrifice limit input decimal

### DIFF
--- a/javascripts/components/infinity/autobuyers/sacrifice-autobuyer-box.js
+++ b/javascripts/components/infinity/autobuyers/sacrifice-autobuyer-box.js
@@ -10,7 +10,7 @@ Vue.component("sacrifice-autobuyer-box", {
     },
     limitInputSetup() {
       return new AutobuyerInputSetup(
-        AutobuyerInputType.FLOAT,
+        AutobuyerInputType.DECIMAL,
         () => this.autobuyer.limit,
         value => this.autobuyer.limit = value
       );


### PR DESCRIPTION
There was a bug where finishing IC2 and going to autobuyer tab makes the limit reactive. Hopefully this fixes it. Not sure how to replicate the bug on master, but taking an early second eternity save and playing through might work.