### PR TITLE
Fix reactive auto-sacrifice bug

### DIFF
--- a/javascripts/components/infinity/autobuyers/sacrifice-autobuyer-box.js
+++ b/javascripts/components/infinity/autobuyers/sacrifice-autobuyer-box.js
@@ -10,7 +10,7 @@ Vue.component("sacrifice-autobuyer-box", {
     },
     limitInputSetup() {
       return new AutobuyerInputSetup(
-        AutobuyerInputType.FLOAT,
+        AutobuyerInputType.DECIMAL,
         () => this.autobuyer.limit,
         value => this.autobuyer.limit = value
       );

--- a/javascripts/core/eternity.js
+++ b/javascripts/core/eternity.js
@@ -145,7 +145,7 @@ function initializeResourcesAfterEternity() {
   player.noEighthDimensions = true;
   player.postChallUnlocked = Achievement(133).isEnabled ? 8 : 0;
   if (player.eternities < 7 && !Achievement(133).isEnabled) {
-    player.autoSacrifice = 1;
+    player.autoSacrifice = 5;
   }
 }
 

--- a/javascripts/core/player.js
+++ b/javascripts/core/player.js
@@ -113,7 +113,7 @@ let player = {
   totalTickBought: 0,
   offlineProd: 0,
   offlineProdCost: 1e7,
-  autoSacrifice: 1,
+  autoSacrifice: 5,
   replicanti: {
     amount: new Decimal(0),
     unl: false,

--- a/javascripts/core/reality.js
+++ b/javascripts/core/reality.js
@@ -317,7 +317,7 @@ function completeReality(force, reset, auto = false) {
   player.offlineProd = isRUPG10Bought ? player.offlineProd : 0;
   player.offlineProdCost = isRUPG10Bought ? player.offlineProdCost : 1e7;
   if (!isRUPG10Bought) {
-    player.autoSacrifice = 1;
+    player.autoSacrifice = 5;
   }
   player.eternityChalls = {};
   player.reality.lastAutoEC = 0;


### PR DESCRIPTION
I've confirmed that completing IC2 with these changes no longer crashes your game, in that I was able to reliably reproduce the bug on master and the bug never showed up under the same conditions on this branch.

I can't say I'm entirely sure why setting the default to something other than 1 was important to the solution, but that seemed to fix it.  Perhaps someone who has a better grasp of the autobuyer code can investigate why, or we could just take a pragmatic approach and merge it and hope nobody breathes on the autobuyer code too hard and breaks it again.  Either way really.