### PR TITLE
Fixes outdated discord server link in news ticker

### DIFF
--- a/javascripts/core/secret-formula/news.js
+++ b/javascripts/core/secret-formula/news.js
@@ -841,7 +841,7 @@ GameDatabase.news = [
     id: "a172",
     text:
       "If you notice any issues with a news ticker message, please report them on the " +
-      "<a href='https://discord.gg/Z628PkM' target='_blank'>Discord</a> by clicking that link right there."
+      "<a href='https://discord.gg/ST9NaXa' target='_blank'>Discord</a> by clicking that link right there."
   },
   {
     id: "a173",


### PR DESCRIPTION
Old link in the news ticker was expired. Changed link to the one used in the old UI's footer.