### PR TITLE
support sacrificing glyphs by drag and drop onto sacrifice info

### DIFF
--- a/javascripts/components/reality/glyphs/glyph-component.js
+++ b/javascripts/components/reality/glyphs/glyph-component.js
@@ -340,9 +340,13 @@ Vue.component("glyph-component", {
       this.suppressTooltip = true;
       ev.dataTransfer.setData(GLYPH_MIME_TYPE, this.glyph.id.toString());
       ev.dataTransfer.dropEffect = "move";
-      this.$viewModel.draggingUIID = this.componentID;
       const rect = this.$refs.over.getBoundingClientRect();
       ev.dataTransfer.setDragImage(this.$refs.over, ev.clientX - rect.left, ev.clientY - rect.top);
+      this.$viewModel.draggingUIID = this.componentID;
+      const dragInfo = this.$viewModel.tabs.reality.draggingGlyphInfo;
+      dragInfo.id = this.glyph.id;
+      dragInfo.type = this.glyph.type;
+      dragInfo.sacrificeValue = glyphSacrificeGain(this.glyph);
     },
     dragEnd() {
       this.isDragging = false;

--- a/javascripts/core/app/ui.init.js
+++ b/javascripts/core/app/ui.init.js
@@ -19,6 +19,11 @@ let ui = {
       reality: {
         openGlyphWeights: false,
         currentGlyphTooltip: -1,
+        draggingGlyphInfo: {
+          id: 0,
+          type: "",
+          sacrificeValue: 0,
+        },
         automator: {
           fullScreen: false,
           editorScriptID: "",

--- a/javascripts/core/rm.js
+++ b/javascripts/core/rm.js
@@ -640,8 +640,8 @@ function glyphRefinementGain(glyph) {
   return Math.clamp(glyphMaxValue - alchemyResource.amount, 0, 0.01 * glyphMaxValue);
 }
 
-function sacrificeGlyph(glyph, force = false) {
-  if (AutoGlyphSacrifice.mode === AutoGlyphSacMode.ALCHEMY && glyph.type !== "reality") {
+function sacrificeGlyph(glyph, force = false, noAlchemy = false) {
+  if (!noAlchemy && AutoGlyphSacrifice.mode === AutoGlyphSacMode.ALCHEMY && glyph.type !== "reality") {
     const resource = glyphAlchemyResource(glyph);
     const refinementGain = glyphRefinementGain(glyph);
     resource.amount += refinementGain;

--- a/stylesheets/glyphs.css
+++ b/stylesheets/glyphs.css
@@ -451,6 +451,18 @@
   padding-bottom: 1rem;
 }
 
+.c-sacrificed-glyphs--dragover {
+  border-color: rgb(0, 0, 0);
+  box-shadow: 0 0 0.1rem 0.1rem  rgb(0, 0, 0);
+}
+
+.t-dark .c-sacrificed-glyphs--dragover,
+.t-dark-metro .c-sacrificed-glyphs--dragover,
+.t-s6 .c-sacrificed-glyphs--dragover {
+  border-color: rgb(255, 255, 255);
+  box-shadow: 0 0 0.1rem 0.1rem  rgb(255, 255, 255);
+}
+
 .c-sacrificed-glyphs__header {
   font-size: 1.2rem;
   font-weight: bold;
@@ -473,6 +485,14 @@
 .c-sacrificed-glyphs__type-amount {
   font-size: 1.5rem;
   font-weight: bold;
+}
+
+.c-sacrificed-glyphs__type-new-amount {
+  color: rgb(0, 180, 0);
+}
+
+.t-s8 .c-sacrificed-glyphs__type-new-amount {
+  color: rgb(0, 80, 0);
 }
 
 .l-glyph-inventory {


### PR DESCRIPTION
A little ugly, because I wanted to show the sacrifice value before the drop event.

You can't get at the drop data in a dragover handler, so the information about the glyph has to be snuck in.