### PR TITLE
make autobuyer interval handling not effectively round the interval

### DIFF
--- a/javascripts/core/autobuyers/autobuyer.js
+++ b/javascripts/core/autobuyers/autobuyer.js
@@ -70,7 +70,12 @@ class IntervaledAutobuyerState extends AutobuyerState {
   }
 
   tick() {
-    this.data.lastTick = player.realTimePlayed;
+    const realTimePlayed = player.realTimePlayed;
+    const interval = this.interval;
+    // Don't allow more than one interval worth of time to accumulate (at most one autobuyer tick)
+    this.data.lastTick = Math.max(
+      Math.min(this.data.lastTick + interval, realTimePlayed),
+      realTimePlayed - interval);
   }
 
   upgradeInterval() {


### PR DESCRIPTION
The 50ms interval was getting rounded up to 66ms