### PR TITLE
make canCrunch use max am this infinity instead of current am

### DIFF
--- a/javascripts/core/big_crunch.js
+++ b/javascripts/core/big_crunch.js
@@ -10,17 +10,8 @@ function bigCrunchAnimation() {
 function canCrunch() {
   const challenge = NormalChallenge.current || InfinityChallenge.current;
   const goal = challenge === undefined ? Decimal.MAX_NUMBER : challenge.goal;
-  if (player.antimatter.lt(goal)) return false;
+  if (player.thisInfinityMaxAM.lt(goal)) return false;
   return true;
-}
-
-// Used to prevent galaxies and dimboosts when you can crunch (pre-break and in challenges only)
-function disallowOtherResets() {
-  const challenge = NormalChallenge.current || InfinityChallenge.current;
-  const goal = challenge === undefined ? Decimal.MAX_NUMBER : challenge.goal;
-  if ((!player.break || challenge !== undefined) && player.antimatter.gte(goal)) return true;
-
-  return false;
 }
 
 function handleChallengeCompletion() {

--- a/javascripts/core/dimboost.js
+++ b/javascripts/core/dimboost.js
@@ -136,7 +136,6 @@ function skipResetsIfPossible() {
 
 function softResetBtnClick() {
   if ((!player.break && player.antimatter.gt(Decimal.MAX_NUMBER)) || !DimBoost.requirement.isSatisfied) return;
-  if (disallowOtherResets()) return;
   if (Ra.isRunning) return;
   if (BreakInfinityUpgrade.bulkDimBoost.isBought) maxBuyDimBoosts(true);
   else softReset(1);

--- a/javascripts/core/galaxy.js
+++ b/javascripts/core/galaxy.js
@@ -148,7 +148,6 @@ function galaxyReset() {
 }
 
 function galaxyResetBtnClick() {
-  if (disallowOtherResets()) return false;
   if (EternityMilestone.autobuyMaxGalaxies.isReached && !shiftDown) return maxBuyGalaxies(true);
   if (!Galaxy.canBeBought || !Galaxy.requirement.isSatisfied) return false;
   galaxyReset();


### PR DESCRIPTION
This means the logic that disallows other resets can be removed, since those no longer hide the crunch button