### PR TITLE
fix overflow of some glyph effects by making them decimal; fixes #986

### DIFF
--- a/javascripts/core/glyph-effects.js
+++ b/javascripts/core/glyph-effects.js
@@ -135,10 +135,10 @@ class GlyphEffectConfig {
     const emptyCombine = setup.combine([]);
     if (typeof emptyCombine !== "number" && !(emptyCombine instanceof Decimal)) {
       if (emptyCombine.value === undefined || emptyCombine.capped === undefined) {
-        throw new Error(`combine function for glyph effect "${setup.id}" has invalid return type`);
+        throw new Error(`The combine function for glyph effect "${setup.id}" has invalid return type`);
       }
       if (setup.softcap) {
-        throw new Error(`combine function for glyph effect "${setup.id}" gives capped information, ` +
+        throw new Error(`The combine function for glyph effect "${setup.id}" gives capped information, ` +
           `but there's also a softcap method`);
       }
     }


### PR DESCRIPTION
What it sounds like. This seemed like an easy good first issue so I took it. I did the same for the other two properties that seemed like they might overflow.