### PR TITLE
fix the description of glyph refinement to use the new formula

### DIFF
--- a/javascripts/components/celestials/subtabs/ra/alchemy-tab.js
+++ b/javascripts/components/celestials/subtabs/ra/alchemy-tab.js
@@ -197,13 +197,12 @@ Vue.component("alchemy-tab", {
     },
     showAlchemyHowTo() {
       Modal.message.show("You can now refine glyphs using \"Alchemy Mode\" in the glyph auto-sacrifice settings. " +
-        "Refined glyphs will give their level cubed divided by 10 billion in alchemy resources, scaled linearly " +
-        "with rarity. For example, 6000^3 / 1e10 = 21.6, so a 70% rarity level 6000 glyph will give 0.7 * 21.6 = " +
-        "15.12 of its resource. Alchemy reactions can be toggled on and off by clicking the respective nodes, and " +
-        "each resource gives its own boost to various resources in the game. Basic resource totals are limited to " +
-        "100 times the gain from refining a perfect glyph of the same level, and compound resource totals are " +
-        "limited to the amount of the reactants. All active alchemy reactions are applied once per reality, " +
-        "unaffected by amplification. You can show the current totals of all alchemy resources by holding shift.");
+        "Refined glyphs will give an amount of their alchemy resources based on their level and rarity. Alchemy " +
+        "reactions can be toggled on and off by clicking the respective nodes, and each resource gives its own " +
+        "boost to various resources in the game. Basic resource totals are limited to 100 times the gain from " +
+        "refining a perfect glyph of the same level, and compound resource totals are limited to the amount of " +
+        "the reactants. All active alchemy reactions are applied once per reality, unaffected by amplification. " +
+        "You can show the current totals of all alchemy resources by holding shift.");
     },
     setAllReactions(value) {
       for (const reaction of AlchemyReactions.all.compact()) {


### PR DESCRIPTION
What it says, doesn't affect gameplay. The 10 billion is the product of the division by 100 and the division by 100 million. I haven't tested, though, so my formula could be wrong somehow.

Also apparently removes some trailing spaces due to my editor automatically doing it? I don't like trailing spaces but it might not make sense to remove them in this PR since it's not changing that code otherwise. Let me know if I should undo the trailing space removal (my guess is yes, I should undo it, but it would feel really stupid to undo it and then redo it so I'll wait for feedback).

If small PRs are annoying I can do bigger PRs; just let me know. Also, Spectral, sorry for making you a reviewer but you seemed most likely to know if the new description was correct.