### PR TITLE
Stop dark matter dimension interval from being buyable below 50ms

### DIFF
--- a/javascripts/components/celestials/subtabs/matter-dimension-row.js
+++ b/javascripts/components/celestials/subtabs/matter-dimension-row.js
@@ -9,14 +9,14 @@ Vue.component("matter-dimension-row", {
       chance: 0,
       interval: new Decimal(0),
       power: new Decimal(0),
-      baseInterval: new Decimal(0),
       chanceCost: 0,
       intervalCost: 0,
       powerCost: 0,
       amount: new Decimal(0),
       canBuyChance: false,
       canBuyInterval: false,
-      canBuyPower: false
+      canBuyPower: false,
+      isIntervalCapped: false,
     };
   },
   methods: {
@@ -24,7 +24,6 @@ Vue.component("matter-dimension-row", {
       this.chance = this.dimension.chance;
       this.interval.copyFrom(this.dimension.interval);
       this.power.copyFrom(this.dimension.power);
-      this.baseInterval.copyFrom(this.dimension.baseInterval);
       this.chanceCost = this.dimension.chanceCost;
       this.intervalCost = this.dimension.intervalCost;
       this.powerCost = this.dimension.powerCost;
@@ -32,6 +31,7 @@ Vue.component("matter-dimension-row", {
       this.canBuyChance = this.dimension.canBuyChance;
       this.canBuyInterval = this.dimension.canBuyInterval;
       this.canBuyPower = this.dimension.canBuyPower;
+      this.isIntervalCapped = this.dimension.isIntervalCapped;
     }
   },
   template:
@@ -48,7 +48,7 @@ Vue.component("matter-dimension-row", {
         @click="dimension.buyInterval()" 
         class="o-matter-dimension-button" 
         :class="{ 'o-matter-dimension-button--available': canBuyInterval }"> 
-        {{ interval.toFixed(2) }}ms <span v-if="baseInterval.gt(50)"><br>Cost: {{ shorten(intervalCost, 2, 0) }}</span>
+        {{ interval.toFixed(2) }}ms <span v-if="!isIntervalCapped"><br>Cost: {{ shorten(intervalCost, 2, 0) }}</span>
       </button>
       <button 
         @click="dimension.buyPower()" 

--- a/javascripts/core/celestials/laitela/matter_dimension.js
+++ b/javascripts/core/celestials/laitela/matter_dimension.js
@@ -33,6 +33,10 @@ class MatterDimensionState {
      .times(Decimal.pow(2, this._tier))
      .times(1000);
   }
+  
+  get isIntervalCapped() {
+    return this.baseInterval.lte(50);
+  }
 
   // In milliseconds
   get interval() {
@@ -90,7 +94,7 @@ class MatterDimensionState {
   }
 
   get canBuyInterval() {
-    return this.intervalCost.lte(player.celestials.laitela.matter) && this.baseInterval.gt(50);
+    return this.intervalCost.lte(player.celestials.laitela.matter) && !this.isIntervalCapped;
   }
 
   get canBuyPower() {


### PR DESCRIPTION
What it sounds like. There was a check for the interval not being equal to 50ms that needed to be changed to the base interval being greater than 50ms. Also there was a similar check in the display which I also changed.

At this point it's clear the spaces issue is going to continue to come up if I don't do anything. I'll switch back to VS Code and undo the stripping of trailing spaces in this and my other PR.