### PR TITLE
change the cardinality formula

### DIFF
--- a/javascripts/core/secret-formula/celestials/alchemy.js
+++ b/javascripts/core/secret-formula/celestials/alchemy.js
@@ -64,7 +64,7 @@ GameDatabase.celestials.alchemy = {
       name: "Cardinality",
       symbol: "α",
       isBaseResource: false,
-      effect: amount => 1.2 - 0.1 * (amount / 20000),
+      effect: amount => 1 + 0.2 / (1 + amount / 20000),
       tier: 2,
       uiOrder: 3,
       isUnlocked: () => Ra.pets.effarig.level >= 7,


### PR DESCRIPTION
The new formula is stronger before 20k and weaker after. Here's a table (remember that this is a slowdown, so smaller = more powerful):

| Resource amount | Old formula | New formula |
| --- | --- | --- |
| 0 | 1.2 | 1.2 | 
| 5000 | 1.175 | 1.16 | 
| 10000 | 1.15 | 1.133 | 
| 15000 | 1.125 | 1.114 | 
| 20000 | 1.1 | 1.1 | 
| 30000 | 1.05 | 1.08 | 
| 40000 | 1.0 | 1.067 | 
| 80000 | 0.8 | 1.04 | 

I think this probably isn't a big enough nerf to cardinality, especially combined with alternation which is what I'm really frightened about (I think that if dilation is completely counteracted by alternation, then that's an issue because of things like dilationpow and stronger galaxies in dilation).

I'm making both Garnet and Spectral reviewers since this PR seems likely to have a lot of mathing stuff out.

Fixes #998 