### PR TITLE
fix royal flush by adding BASIC_GLYPH_TYPES

### DIFF
--- a/javascripts/core/devtools.js
+++ b/javascripts/core/devtools.js
@@ -335,9 +335,9 @@ dev.testGlyphs = function(config) {
     withFirst.forEach(e => e.push(elements[0]));
     return withFirst.concat(withoutFirst);
   }
-  const sets5 = makeCombinationsWithRepeats(5, GLYPH_TYPES.slice(0, 5))
+  const sets5 = makeCombinationsWithRepeats(5, BASIC_GLYPH_TYPES)
     .map(s => s.map(t => makeAllEffectGlyph(t)));
-  const sets4 = makeCombinationsWithRepeats(4, GLYPH_TYPES.slice(0, 5))
+  const sets4 = makeCombinationsWithRepeats(4, BASIC_GLYPH_TYPES)
     .map(s => s.map(t => makeAllEffectGlyph(t)));
   const effarigSets = effarigGlyphs.map(g => sets4.map(s => [g].concat(s)));
   const glyphSets = sets5.concat(...effarigSets);

--- a/javascripts/core/glyph-effects.js
+++ b/javascripts/core/glyph-effects.js
@@ -4,6 +4,7 @@
 
 // The last glyph type you can only get if you got effarig reality
 const GLYPH_TYPES = ["time", "dilation", "replication", "infinity", "power", "effarig", "reality", "cursed"];
+const BASIC_GLYPH_TYPES = ["time", "dilation", "replication", "infinity", "power"];
 const GLYPH_SYMBOLS = { time: "Δ", dilation: "Ψ", replication: "Ξ", infinity: "∞", power: "Ω",
   effarig: "Ϙ", reality: "Ϟ", cursed: "⸸" };
 const CANCER_GLYPH_SYMBOLS = { time: "🕟", dilation: "☎", replication: "⚤", infinity: "8", power: "⚡",

--- a/javascripts/core/secret-formula/achievements/normal-achievements.js
+++ b/javascripts/core/secret-formula/achievements/normal-achievements.js
@@ -960,8 +960,7 @@ GameDatabase.achievements.normal = [
     id: 148,
     name: "Royal Flush",
     tooltip: "Reality with one of each basic glyph type.",
-    checkRequirement: () => GLYPH_TYPES
-      .filter(type => type !== "effarig" && type !== "reality")
+    checkRequirement: () => BASIC_GLYPH_TYPES
       .every(type => Glyphs.activeList.some(g => g.type === type)),
     checkEvent: GameEvent.REALITY_RESET_BEFORE
   },


### PR DESCRIPTION
Add a new BASIC_GLYPH_TYPES list which is just the five basic glyph types. Use it for Royal Flush checking. Also use it in devtools rather than GLYPH_TYPES.slice(0, 5) (which is the same value but less clear).

Fixes #1003