### PR TITLE
boost d2 and d4 mults as in live version in Challenge 12

### DIFF
--- a/javascripts/core/dimensions/normal-dimension.js
+++ b/javascripts/core/dimensions/normal-dimension.js
@@ -99,16 +99,10 @@ function getDimensionFinalMultiplierUncached(tier) {
 function applyNDMultipliers(mult, tier) {
   let multiplier = mult.times(GameCache.normalDimensionCommonMultiplier.value);
 
-  let buy10AndDimboostContribution = Decimal.pow(
+  multiplier = multiplier.times(Decimal.pow(
     NormalDimensions.buyTenMultiplier, Math.floor(NormalDimension(tier).bought / 10)
-  ).times(DimBoost.multiplierToNDTier(tier));
-
-  if (NormalChallenge(12).isRunning) {
-    if (tier === 2) buy10AndDimboostContribution = buy10AndDimboostContribution.pow(1.7);
-    if (tier === 4) buy10AndDimboostContribution = buy10AndDimboostContribution.pow(1.4);
-  }
-
-  multiplier = multiplier.times(buy10AndDimboostContribution);
+    ));
+  multiplier = multiplier.times(DimBoost.multiplierToNDTier(tier));
 
   let infinitiedMult = new Decimal(1).timesEffectsOf(
     NormalDimension(tier).infinityUpgrade,
@@ -377,8 +371,9 @@ function getDimensionProductionPerSecond(tier) {
   const dimension = NormalDimension(tier);
   let amount = dimension.amount.floor();
   if (NormalChallenge(12).isRunning) {
-    if (tier === 2) amount = amount.pow(1.5);
-    if (tier === 4) amount = amount.pow(1.3);
+    if (tier === 2) amount = amount.pow(1.6);
+    if (tier === 4) amount = amount.pow(1.4);
+    if (tier === 6) amount = amount.pow(1.2);
   }
   let production = amount.times(multiplier).dividedBy(Tickspeed.current.dividedBy(1000));
   if (NormalChallenge(2).isRunning) {

--- a/javascripts/core/secret-formula/challenges/normal-challenges.js
+++ b/javascripts/core/secret-formula/challenges/normal-challenges.js
@@ -89,7 +89,8 @@ GameDatabase.challenges.normal = [
     id: 12,
     legacyId: 7,
     isQuickResettable: false,
-    description: "Each dimension produces the dimension 2 below it; 1st Dimensions produce reduced antimatter.",
+    description: "Each dimension produces the dimension 2 below it (1st Dimensions still " +
+      "produce antimatter). Dimensions 2, 4, and 6 are made stronger to compensate.",
     reward: "Automated Big Crunches"
   }
 ];


### PR DESCRIPTION
Fixes #1005

Copying the issue description: In live d2 and d4 melts are raised to a power (confusingly, Challenge 12 is called challenge7 in live). In test they aren't (the amounts are raised to a different power in calculating production, but that's different and also happens in live).

Honestly what live does is a huge mess and if something else is mathematically equivalent or close enough I'm happy to go with that. The reason d2 and d4 are boosted in the first place is that the even dimensions should be stronger than the odd dimensions so that d8 helps, but maybe there's an easier way to do this.