### PR TITLE
Add offline progress

### DIFF
--- a/javascripts/components/options/options-button-grid.js
+++ b/javascripts/components/options/options-button-grid.js
@@ -38,6 +38,7 @@ Vue.component("options-button-grid", {
       cloud: false,
       hotkeys: false,
       commas: false,
+      offlineProgress: false,
       updateRate: 0
     };
   },
@@ -53,6 +54,9 @@ Vue.component("options-button-grid", {
     },
     commas(newValue) {
       player.options.commas = newValue;
+    },
+    offlineProgress(newValue) {
+      player.options.offlineProgress = newValue;
     },
     updateRate(newValue) {
       player.options.updateRate = newValue;
@@ -78,6 +82,7 @@ Vue.component("options-button-grid", {
       this.cloud = options.cloud;
       this.hotkeys = options.hotkeys;
       this.commas = options.commas;
+      this.offlineProgress = options.offlineProgress;
       this.updateRate = options.updateRate;
     },
     hardReset() {
@@ -170,14 +175,27 @@ Vue.component("options-button-grid", {
           class="o-primary-btn--option_font-large"
           onclick="GameOptions.toggleUI()"
         >{{ UILabel }}</options-button>
-        <update-rate-slider
-          v-model="updateRate"
-          oninput="GameOptions.refreshUpdateRate()"
+        <primary-button-on-off
+          class="o-primary-btn--option l-options-grid__button"
+          v-model="offlineProgress"
+          text="Offline progress:"
         />
         <options-button
           class="o-primary-btn--option_font-large"
           onclick="Modal.animationOptions.show();"
         >Animations</options-button>
+      </div>
+      <div class="l-options-grid__row">
+        <options-button
+           class="o-primary-btn--option l-options-grid__button--hidden"
+         />
+        <update-rate-slider
+          v-model="updateRate"
+          oninput="GameOptions.refreshUpdateRate()"
+        />
+        <options-button
+           class="o-primary-btn--option l-options-grid__button--hidden"
+         />
       </div>
     </div>`
 });

--- a/javascripts/core/player.js
+++ b/javascripts/core/player.js
@@ -465,6 +465,7 @@ let player = {
     commas: true,
     updateRate: 33,
     newUI: true,
+    offlineProgress: true,
     showAlchemyResources: false,
     chart: {
       updateRate: 1000,

--- a/javascripts/core/storage/storage.js
+++ b/javascripts/core/storage/storage.js
@@ -142,13 +142,16 @@ const GameStorage = {
     if (overrideLastUpdate) {
       player.lastUpdate = overrideLastUpdate;
     }
-    let diff = Date.now() - player.lastUpdate;
-    if (diff > 5 * 60 * 1000 && player.celestials.enslaved.autoStoreReal) {
-      diff = Enslaved.autoStoreRealTime(diff);
-    }
-
-    if (diff > 1000 * 1000) {
-      simulateTime(diff / 1000);
+    if (player.options.offlineProgress) {
+      let diff = Date.now() - player.lastUpdate;
+      if (diff > 5 * 60 * 1000 && player.celestials.enslaved.autoStoreReal) {
+        diff = Enslaved.autoStoreRealTime(diff);
+      }
+      if (diff > 1000 * 1000) {
+        simulateTime(diff / 1000);
+      }
+    } else {
+      player.lastUpdate = Date.now();
     }
     Enslaved.nextTickDiff = player.options.updateRate;
     GameUI.update();


### PR DESCRIPTION
Fixes #824 

Currently when loading a save offline progress is based on the loaded save rather than the pre-loading setting; I'm not sure if this current behavior is desirable, though I think it isn't. On the one hand, this means that if you don't like off-line progress and you export your save and later load it on, for example, a new browser, you don't have to remember to turn off offline progress before loading. On the other hand, this means that if you have a save with a particular offline progress setting, you need to change the save itself to get the other setting.