### PR TITLE
Fix #1020

### DIFF
--- a/javascripts/core/dimensions/normal-dimension.js
+++ b/javascripts/core/dimensions/normal-dimension.js
@@ -276,6 +276,7 @@ function buyUntilTen(tier) {
   dimension.challengeCostBump();
   dimension.amount = Decimal.round(dimension.amount.plus(dimension.remainingUntil10));
   dimension.bought += dimension.remainingUntil10;
+  onBuyDimension(tier);
 }
 
 function maxAll() {
@@ -319,7 +320,6 @@ function buyMaxDimension(tier, bulk = Infinity, auto = false) {
       buyUntilTen(tier);
       bulkLeft--;
     }
-    onBuyDimension(tier);
     return;
   }
 
@@ -335,7 +335,6 @@ function buyMaxDimension(tier, bulk = Infinity, auto = false) {
   dimension.amount = dimension.amount.plus(10 * buying).round();
   dimension.bought += 10 * buying;
   dimension.currencyAmount = dimension.currencyAmount.minus(Decimal.pow10(maxBought.logPrice));
-  onBuyDimension(tier);
   const multAfter = Decimal.pow(NormalDimensions.buyTenMultiplier, dimension.bought / 10);
   if (multBefore.neq(multAfter) && auto === false) {
     floatText(tier, `x${shorten(multAfter.dividedBy(multBefore), 2, 1)}`);

--- a/javascripts/core/secret-formula/achievements/normal-achievements.js
+++ b/javascripts/core/secret-formula/achievements/normal-achievements.js
@@ -4,53 +4,53 @@ GameDatabase.achievements.normal = [
   {
     id: 11,
     name: "You gotta start somewhere",
-    tooltip: "Buy a single 1st Dimension.",
+    tooltip: "Buy a 1st Dimension.",
     checkEvent: GameEvent.ACHIEVEMENT_EVENT_OTHER,
   },
   {
     id: 12,
     name: "100 antimatter is a lot",
-    tooltip: "Buy a single 2nd Dimension.",
+    tooltip: "Buy a 2nd Dimension.",
     checkEvent: GameEvent.ACHIEVEMENT_EVENT_OTHER,
   },
   {
     id: 13,
     name: "Half life 3 confirmed",
-    tooltip: "Buy a single 3rd Dimension.",
+    tooltip: "Buy a 3rd Dimension.",
     checkEvent: GameEvent.ACHIEVEMENT_EVENT_OTHER,
   },
   {
     id: 14,
     name: "L4D: Left 4 Dimensions",
-    tooltip: "Buy a single 4th Dimension.",
+    tooltip: "Buy a 4th Dimension.",
     checkEvent: GameEvent.ACHIEVEMENT_EVENT_OTHER,
   },
   {
     id: 15,
     name: "5 Dimension Antimatter Punch",
-    tooltip: "Buy a single 5th Dimension.",
+    tooltip: "Buy a 5th Dimension.",
     checkEvent: GameEvent.ACHIEVEMENT_EVENT_OTHER,
   },
   {
     id: 16,
     name: "We couldn't afford 9",
     tooltip: () => (Enslaved.isRunning
-      ? "Buy a single 6th Dimension (they never amount to anything)"
-      : "Buy a single 6th Dimension."),
+      ? "Buy a 6th Dimension (they never amount to anything)"
+      : "Buy a 6th Dimension."),
       checkEvent: GameEvent.ACHIEVEMENT_EVENT_OTHER,
     },
   {
     id: 17,
     name: "Not a luck related achievement",
-    tooltip: "Buy a single 7th Dimension.",
+    tooltip: "Buy a 7th Dimension.",
     checkEvent: GameEvent.ACHIEVEMENT_EVENT_OTHER,
   },
   {
     id: 18,
     name: "90 degrees to infinity",
     tooltip: () => (Enslaved.isRunning
-      ? "Buy a single 8th Dimension (don't get used to it)"
-      : "Buy a single 8th Dimension."),
+      ? "Buy an 8th Dimension (don't get used to it)"
+      : "Buy an 8th Dimension."),
       checkEvent: GameEvent.ACHIEVEMENT_EVENT_OTHER,
     },
   {


### PR DESCRIPTION
Make buying 10 of a dimension also give that dimension's first-row achievement

I think this code should work but other people should probably check my logic. My logic is that the amount remaining until 10 is always at least 1 (it's 10 minus (something mod 10)), so whenever you call `buyUntilTen` you're buying at least one and thus we can safely call `onBuyDimension`. Furthermore, in `buyMaxDimension`, if you get to the bottom, you already called `buyUntilTen` which (now) calls `onBuyDimension`, so we can remove the call to `onBuyDimension` at the bottom of `buyMaxDimension`. But as I said, I'm not too confident in this logic and someone else should probably check it.