### PR TITLE
Fix wording of dimboostNonReset perk

### DIFF
--- a/javascripts/core/dimboost.js
+++ b/javascripts/core/dimboost.js
@@ -102,13 +102,13 @@ function softReset(bulk, forcedNDReset = false, forcedAMReset = false) {
     /**
      * All reset stuff are in these functions now. (Hope this works)
      */
-    player.sacrificed = new Decimal(0);
     resetChallengeStuff();
     if (forcedNDReset || !Perk.dimboostNonReset.isBought) {
       NormalDimensions.reset();
+      player.sacrificed = new Decimal(0);
+      resetTickspeed();
     }
     skipResetsIfPossible();
-    resetTickspeed();
     const currentAntimatter = player.antimatter;
     player.antimatter = Player.startingAM;
     if (!forcedAMReset && (Achievement(111).isEnabled || Perk.dimboostNonReset.isBought)) {

--- a/javascripts/core/secret-formula/reality/perks.js
+++ b/javascripts/core/secret-formula/reality/perks.js
@@ -128,7 +128,7 @@ GameDatabase.reality.perks = {
     id: 30,
     label: "DB",
     family: PerkFamily.INFINITY,
-    description: "Dimboosts no longer reset normal dimensions"
+    description: "Dimboosts no longer reset normal dimensions, tickspeed, or sacrifice."
   },
   studyPassive1: {
     id: 31,


### PR DESCRIPTION
Since RG no longer reset anything we don't need to mention them.

I'm also considering buffing this perk to make it so that dimboosts also don't reset anything (sacrifice, tickspeed, I'd probably either let dimboosts still reset challenge things or make them reset bad challenge things like matter but not good challenge things like challenge 3 multiplier). Does that seem like a good idea? If so I can add it to this PR and make another one. I'm honestly not sure what this perk is good for as is (except pre-Yo Dawg); the fact that tickspeed is still reset makes me doubt that it saves a tick.