### PR TITLE
Fix some small bugs

### DIFF
--- a/javascripts/core/secret-formula/achievements/normal-achievements.js
+++ b/javascripts/core/secret-formula/achievements/normal-achievements.js
@@ -694,7 +694,7 @@ GameDatabase.achievements.normal = [
     name: "Never again",
     tooltip: () => `Get the sum of Infinity Challenge times below ${shortenSmallInteger(750)}ms.`,
     checkRequirement: () => Time.infinityChallengeSum.totalMilliseconds < 750,
-    checkEvent: GameEvent.BIG_CRUNCH_AFTER,
+    checkEvent: [GameEvent.BIG_CRUNCH_AFTER, GameEvent.REALITY_RESET_AFTER],
     reward: "The limit for your third eternity upgrade is a bit higher.",
     effect: 610
   },

--- a/javascripts/core/secret-formula/challenges/normal-challenges.js
+++ b/javascripts/core/secret-formula/challenges/normal-challenges.js
@@ -49,7 +49,7 @@ GameDatabase.challenges.normal = [
   {
     id: 7,
     legacyId: 9,
-    isQuickResettable: true,
+    isQuickResettable: false,
     description: "The multiplier from buying 10 dimensions is reduced to 1x, but is increased by 0.2x per " +
       "Dimension Shift/Boost, up to a maximum of 2x.",
     reward: "Seventh Dimension Autobuyer"


### PR DESCRIPTION
Prevent quick resetting in Challenge 7. This was only ever possible, as far as I understand, because of randomization that was removed. Also check for "Never Again" on reality (which will, I think, lead to the player always having that achievement) as well as on infinity, so that the behavior is the same as that of "Yes. This is hell." (The commit message and branch name of this branch were both not that well thought through; checking for "Never Again" on reality is not an early infinity fix and the "start"s in the commit message should probably be "end"s.)