### PR TITLE
Remove special case for shortening 1 point in header.

### DIFF
--- a/javascripts/components/old-ui/header/game-header-amounts-line.js
+++ b/javascripts/components/old-ui/header/game-header-amounts-line.js
@@ -21,7 +21,7 @@ Vue.component("game-header-amounts-line", {
       }
     },
     shortenPoints(points) {
-      return this.shortenDimensions(points);
+      return this.shorten(points, 2, 0);
     }
   },
   template:


### PR DESCRIPTION
Fixes #1025

See that issue's description and the comment on it for more details. (TLDR: "1 Eternity point" shows up in blind notation, this was caused by a special case for 1 in formatting points as part of a long-ago commit, I have no idea why the special case was there, I removed it.)

(I just realized that someone might wonder why I kept the shortenPoints method. I did so because I thought it would be clearer than using shortenDimensions directly to shorten something other than a dimension amount, but I'm happy to use shortenDimensions directly if others think that would be better.)

(Also I just realized that other people might prefer the current behavior. I personally think "You have Eternity point" is far better than "You have 1 Eternity point" in blind notation and "You have C0000000 Eternity point" is somewhat better than "You have 1 Eternity point" in hex notation, but if others disagree, or have the opposite preference for other notations, I can close this PR. Also I'm editing rather than adding comments to avoid email-spamming, since AFAIK editing a comment doesn't send out an email.)