### PR TITLE
Simplify galaxy reset bulk logic and fix #905

### DIFF
--- a/javascripts/components/dimensions/normal/normal-dim-galaxy-row.js
+++ b/javascripts/components/dimensions/normal/normal-dim-galaxy-row.js
@@ -80,7 +80,7 @@ Vue.component("normal-dim-galaxy-row", {
       if (NormalChallenge(8).isRunning) return "Locked (8th Dimension Autobuyer Challenge)";
       return null;
     },
-    buyGalaxy: bulk => galaxyResetBtnClick(bulk),
+    buyGalaxy: bulk => requestGalaxyReset(bulk),
   },
   template:
     `<div class="c-normal-dim-row">

--- a/javascripts/components/new-ui/dimensions-tab/new-galaxy-row.js
+++ b/javascripts/components/new-ui/dimensions-tab/new-galaxy-row.js
@@ -79,7 +79,7 @@ Vue.component("new-galaxy-row", {
       if (NormalChallenge(8).isRunning) return "Locked (8th Dimension Autobuyer Challenge)";
       return null;
     },
-    buyGalaxy: bulk => galaxyResetBtnClick(bulk),
+    buyGalaxy: bulk => requestGalaxyReset(bulk),
   },
   template:
   `<div class="reset-container galaxy">

--- a/javascripts/core/autobuyers/galaxy-autobuyer.js
+++ b/javascripts/core/autobuyers/galaxy-autobuyer.js
@@ -63,6 +63,6 @@ Autobuyer.galaxy = new class GalaxyAutobuyerState extends IntervaledAutobuyerSta
     if (!Galaxy.requirement.isSatisfied) return;
     super.tick();
     const limit = this.limitGalaxies ? this.maxGalaxies : Number.MAX_VALUE;
-    galaxyResetBtnClick(this.isBuyMaxActive, limit);
+    requestGalaxyReset(this.isBuyMaxActive, limit);
   }
 }();

--- a/javascripts/core/galaxy.js
+++ b/javascripts/core/galaxy.js
@@ -147,7 +147,7 @@ function galaxyReset() {
   EventHub.dispatch(GameEvent.GALAXY_RESET_AFTER);
 }
 
-function galaxyResetBtnClick(bulk, limit = Number.MAX_VALUE) {
+function requestGalaxyReset(bulk, limit = Number.MAX_VALUE) {
   if (EternityMilestone.autobuyMaxGalaxies.isReached && bulk) return maxBuyGalaxies(limit);
   if (player.galaxies >= limit || !Galaxy.canBeBought || !Galaxy.requirement.isSatisfied) return false;
   galaxyReset();

--- a/javascripts/core/hotkeys.js
+++ b/javascripts/core/hotkeys.js
@@ -11,7 +11,8 @@
 
 GameKeyboard.bindRepeatableHotkey("m", () => maxAll());
 GameKeyboard.bindRepeatableHotkey("d", () => softResetBtnClick());
-GameKeyboard.bindRepeatableHotkey("g", () => galaxyResetBtnClick(true));
+GameKeyboard.bindRepeatableHotkey("g", () => requestGalaxyReset(true));
+GameKeyboard.bindRepeatableHotkey("shift+g", () => requestGalaxyReset(false));
 GameKeyboard.bindRepeatableHotkey("s", () => sacrificeBtnClick());
 GameKeyboard.bindRepeatableHotkey("r", () => replicantiGalaxy());
 GameKeyboard.bindRepeatableHotkey("t", () => buyMaxTickSpeed());


### PR DESCRIPTION
I think I've tested all cases of this but I might have missed one, or my second commit might have broken one. Also galaxyResetBtnClick is now called even by the galaxy autobuyer so its name probably needs to change, but I don't know to what.