### PR TITLE
galactic + newui text fix

### DIFF
--- a/stylesheets/theme-S6.css
+++ b/stylesheets/theme-S6.css
@@ -17,7 +17,7 @@
 }
 
 body.t-s6 {
-  color: #999;
+  color: white;
   background: black;
   background-image: url('../images/s6-bg.png');
   background-size: 100%;


### PR DESCRIPTION
originally the text on infdim and timedim was grey on galactic + newui and looked like this
![image](https://user-images.githubusercontent.com/35183947/72754371-37c05300-3b8d-11ea-85fc-74e293195f0f.png)
in this fix, the text now looks like this
![image](https://user-images.githubusercontent.com/35183947/72754406-49095f80-3b8d-11ea-8ce5-094100f5d818.png)
alTHOUGH:
![image](https://user-images.githubusercontent.com/35183947/72754429-5aeb0280-3b8d-11ea-9e5a-f268a590ccd7.png) **it changes the grey text on this (and all other grey text) to white. i believe we'd have to change the ID and TD mult/number text to a different id, but with the changes to the code and stuff i have no idea how to do that.**
![image](https://user-images.githubusercontent.com/35183947/72754549-c0d78a00-3b8d-11ea-8108-a29f272247c2.png)

the reason i made this is because the NDs already are white, and i noticed the inconsistency pretty early on.