### PR TITLE
Only show unlock message for a theme that's not already unlocked

### DIFF
--- a/javascripts/core/app/themes.js
+++ b/javascripts/core/app/themes.js
@@ -89,11 +89,11 @@ Theme.tryUnlock = function(name) {
     }
     const prefix = `S${index + 1}`;
     const fullName = prefix + name.capitalize();
-    const alreadyUnlocked = player.secretUnlocks.themes.has(fullName);
+    const isAlreadyUnlocked = player.secretUnlocks.themes.has(fullName);
     player.secretUnlocks.themes.add(fullName);
     Theme.set(prefix);
     SecretAchievement(25).unlock();
-    if (!alreadyUnlocked) {
+    if (!isAlreadyUnlocked) {
       GameUI.notify.success(`You have unlocked the ${name.capitalize()} theme!`);
     }
     return true;


### PR DESCRIPTION
Before, even if you'd already unlocked a secret theme, if you switched to it by importing its name, a notification would pop up saying that you'd unlocked it. This commit makes that notification only show up for a newly unlocked secret theme.

This might not actually be a bug; it seems like a bug to me but I might be wrong. If it's not a bug feel free to close and delete the branch.