### PR TITLE
Fix news message ID

### DIFF
--- a/javascripts/core/secret-formula/news.js
+++ b/javascripts/core/secret-formula/news.js
@@ -1778,14 +1778,14 @@ GameDatabase.news = [
   },
   {
     id: "a309",
-    text: "Testing... testing... testing... Oh goddamn I was in prod again."
-  },
-  {
-    id: "a310",
     get text() {
       return `Check out Avari's newly built actually infinite infinity pool! With an area of ` +
       `${format(Number.MAX_VALUE)} square megametres, you'll be sure to have infinite fun!`;
     }
+  },
+  {
+    id: "a310",
+    text: "Testing... testing... testing... Oh goddamn I was in prod again."
   },
   {
     id: "l1",


### PR DESCRIPTION
There was a duplicate news message ID. If this ID was an intentional joke (which it could easily be), please close it. Also I guess maybe we should have numbered it a310 and left the old one at a309, but it doesn't really matter.

I considered adding a message 'Remember, when you're adding news messages, it's very important to give them the proper ID. The best thing to do is add one to the ID of the previous news message. Adding more than one is bad but not catastrophic because at least there aren't repeats. Giving a long random nonsense ID also avoids repeats. If you subtract, then you have repeat IDs, and who knows what terrible consequences that will have?" with ID a309 or something, but decided against it.