### PR TITLE
Make "Just in case" only count manual saves

### DIFF
--- a/javascripts/components/options/options-button-grid.js
+++ b/javascripts/components/options/options-button-grid.js
@@ -132,7 +132,7 @@ Vue.component("options-button-grid", {
         >Confirmations</options-button>
         <options-button
           class="o-primary-btn--option_font-x-large"
-          onclick="GameStorage.save()"
+          onclick="GameStorage.save(manual = true)"
         >Save</options-button>
         <options-button
           class="o-primary-btn--option_font-x-large"

--- a/javascripts/core/hotkeys.js
+++ b/javascripts/core/hotkeys.js
@@ -67,7 +67,7 @@ GameKeyboard.bindHotkey("h", () => {
 });
 
 GameKeyboard.bindHotkey(["ctrl+s", "meta+s"], () => {
-  GameStorage.save();
+  GameStorage.save(manual = true);
   return false;
 });
 GameKeyboard.bindHotkey(["ctrl+e", "meta+e"], () => {

--- a/javascripts/core/storage/storage.js
+++ b/javascripts/core/storage/storage.js
@@ -77,9 +77,9 @@ const GameStorage = {
     return save !== undefined && save !== null && (save.money !== undefined || save.antimatter !== undefined);
   },
 
-  save(silent = false) {
+  save(silent = false, manual = false) {
     if (GlyphSelection.active || ui.$viewModel.modal.progressBar !== undefined) return;
-    if (++this.saved > 99) SecretAchievement(12).unlock();
+    if (manual && ++this.saved > 99) SecretAchievement(12).unlock();
     const root = {
       current: this.currentSlot,
       saves: this.saves


### PR DESCRIPTION
Manual saves are considered to be those from either using the save hotkeys or clicking the save button. I'm not sure exactly how the playfab stuff works and if any of the saves due to that code ("Cloud save" perhaps) should be considered manual; if you know, please tell me.

This PR fixes #1069.