### PR TITLE
Fix bug where Teresa container shows as empty in certain notations

### DIFF
--- a/javascripts/components/celestials/subtabs/teresa/teresa-tab.js
+++ b/javascripts/components/celestials/subtabs/teresa/teresa-tab.js
@@ -39,7 +39,7 @@ Vue.component("teresa-tab", {
       }
       this.time = now;
       this.rmStore = player.celestials.teresa.rmStore;
-      this.percentage = formatPercents(Teresa.fill, 2);
+      this.percentage = Notations.current.name === 'Blind' ? '0%' : `${(Teresa.fill * 100).toFixed(2)}%`;
       this.rmMult = Teresa.rmMultiplier;
       this.hasReality = Teresa.has(TERESA_UNLOCKS.RUN);
       this.hasEPGen = Teresa.has(TERESA_UNLOCKS.EPGEN);

--- a/javascripts/components/dimensions/normal/normal-dim-tab-progress-bar.js
+++ b/javascripts/components/dimensions/normal/normal-dim-tab-progress-bar.js
@@ -3,17 +3,17 @@
 Vue.component("normal-dim-tab-progress-bar", {
   data() {
     return {
-      fill: new Decimal(0),
+      fill: 0,
       tooltip: ""
     };
   },
   computed: {
-    percents() {
-      return `${this.fill.toFixed(2)}%`;
+    displayPercents() {
+      return formatPercents(this.fill, 2);
     },
     progressBarStyle() {
       return {
-        width: this.percents
+        width: Notations.current.name === 'Blind' ? '0%' : `${this.fill.toFixed(2)}%`
       };
     }
   },
@@ -46,7 +46,7 @@ Vue.component("normal-dim-tab-progress-bar", {
   template:
     `<div class="c-progress-bar">
         <div :style="progressBarStyle" class="c-progress-bar__fill">
-            <span v-tooltip="tooltip" class="c-progress-bar__percents">{{percents}}</span>
+            <span v-tooltip="tooltip" class="c-progress-bar__percents">{{displayPercents}}</span>
           </div>
     </div>`
 });


### PR DESCRIPTION
Also make Teresa container and bottom progress bar empty in Blind notation. Fixes #1072.

I'm unsure if we want the eresa container and bottom progress bar to be empty in Blind notation. Note that some of the changes to bottom progress bar are good ideas even if we don't want it to be empty in Blind notation (e.g., making fill number rather than Decimal, formatting the percentage).