### PR TITLE
Fix some buggy dev migrations

### DIFF
--- a/javascripts/core/storage/dev-migrations.js
+++ b/javascripts/core/storage/dev-migrations.js
@@ -520,12 +520,12 @@ GameStorage.devMigrations = {
       player.reality.glyphs.inventorySize += 10;
     },
     player => {
-      player.celestials.v.unlockBits = 1;
+      player.celestials.v.unlockBits = Math.min(player.celestials.v.unlockBits, 1);
       V.checkForUnlocks();
     },
     player => {
       // Reset the v-unlocks again
-      player.celestials.v.unlockBits = 1;
+      player.celestials.v.unlockBits = Math.min(player.celestials.v.unlockBits, 1);
       V.checkForUnlocks();
     }
   ],


### PR DESCRIPTION
This PR stops V from unlocking when it shouldn't. It doesn't affect saves that have already unlocked V due to the dev migration, but there's not much that can be done there except adding another dev migration that re-locks V on all saves, which seems like a bad idea. The bug this PR fixes is sort of nice because it made V unlock far less of a long maybe-impossible RM grind, but it's a bug, so it had to be fixed.