### PR TITLE
Add option to toggle glyph dots, create miscellaneous options

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,6 +355,7 @@
 <script type="text/javascript" src="javascripts/components/modals/options/modal-animation-options.js"></script>
 <script type="text/javascript" src="javascripts/components/modals/options/modal-confirmation-options.js"></script>
 <script type="text/javascript" src="javascripts/components/modals/options/modal-info-display-options.js"></script>
+<script type="text/javascript" src="javascripts/components/modals/options/modal-miscellaneous-options.js"></script>
 <script type="text/javascript" src="javascripts/components/modals/cloud/modal-cloud-conflict-record.js"></script>
 <script type="text/javascript" src="javascripts/components/modals/cloud/modal-cloud-load-conflict.js"></script>
 <script type="text/javascript" src="javascripts/components/modals/cloud/modal-cloud-save-conflict.js"></script>

--- a/javascripts/components/modals/options/modal-miscellaneous-options.js
+++ b/javascripts/components/modals/options/modal-miscellaneous-options.js
@@ -1,0 +1,31 @@
+"use strict";
+
+Vue.component("modal-miscellaneous-options", {
+  mixins: [modalOptionsMixin],
+  data() {
+    return {
+      offlineProgress: false,
+      showGlyphEffectDots: false,
+    };
+  },
+  watch: {
+    offlineProgress(newValue) {
+      player.options.offlineProgress = newValue;
+    },
+    showGlyphEffectDots(newValue) {
+      player.options.showGlyphEffectDots = newValue;
+    },
+  },
+  methods: {
+    update() {
+      const options = player.options;
+      this.offlineProgress = options.offlineProgress;
+      this.showGlyphEffectDots = options.showGlyphEffectDots;
+    }
+  },
+  template:
+    `<modal-options @close="emitClose">
+      <on-off-button v-model="offlineProgress" text="Offline progress:"/>
+      <on-off-button v-if="realityUnlocked" v-model="showGlyphEffectDots" text="Dots on glyphs (showing effects):"/>
+    </modal-options>`
+});

--- a/javascripts/components/options/options-button-grid.js
+++ b/javascripts/components/options/options-button-grid.js
@@ -38,7 +38,6 @@ Vue.component("options-button-grid", {
       cloud: false,
       hotkeys: false,
       commas: false,
-      offlineProgress: false,
       updateRate: 0
     };
   },
@@ -54,9 +53,6 @@ Vue.component("options-button-grid", {
     },
     commas(newValue) {
       player.options.commas = newValue;
-    },
-    offlineProgress(newValue) {
-      player.options.offlineProgress = newValue;
     },
     updateRate(newValue) {
       player.options.updateRate = newValue;
@@ -82,7 +78,6 @@ Vue.component("options-button-grid", {
       this.cloud = options.cloud;
       this.hotkeys = options.hotkeys;
       this.commas = options.commas;
-      this.offlineProgress = options.offlineProgress;
       this.updateRate = options.updateRate;
     },
     hardReset() {
@@ -175,10 +170,9 @@ Vue.component("options-button-grid", {
           class="o-primary-btn--option_font-large"
           onclick="GameOptions.toggleUI()"
         >{{ UILabel }}</options-button>
-        <primary-button-on-off
-          class="o-primary-btn--option l-options-grid__button"
-          v-model="offlineProgress"
-          text="Offline progress:"
+        <update-rate-slider
+          v-model="updateRate"
+          oninput="GameOptions.refreshUpdateRate()"
         />
         <options-button
           class="o-primary-btn--option_font-large"
@@ -190,10 +184,10 @@ Vue.component("options-button-grid", {
           class="o-primary-btn--option_font-large"
           onclick="Modal.infoDisplayOptions.show()"
         >Info Displays</options-button>
-        <update-rate-slider
-          v-model="updateRate"
-          oninput="GameOptions.refreshUpdateRate()"
-        />
+        <options-button
+          class="o-primary-btn--option_font-large"
+          onclick="Modal.miscellaneousOptions.show()"
+        >Miscellaneous</options-button>
         <options-button
            class="o-primary-btn--option l-options-grid__button--hidden"
          />

--- a/javascripts/components/reality/glyphs/glyph-component.js
+++ b/javascripts/components/reality/glyphs/glyph-component.js
@@ -359,6 +359,7 @@ Vue.component("glyph-component", {
     update() {
       this.isRealityGlyph = this.glyph.type === "reality";
       this.glyphEffects = this.extractGlyphEffects();
+      this.showGlyphEffectDots = player.options.showGlyphEffectDots;
     },
     // This finds all the effects of a glyph and shifts all their IDs so that type's lowest-ID effect is 0 and all
     // other effects count up to 3 (or 6 for effarig). Used to add dots in unique positions on glyphs to show effects.
@@ -526,7 +527,7 @@ Vue.component("glyph-component", {
            :style="innerStyle"
            :class="['l-glyph-component', 'c-glyph-component']">
         {{symbol}}
-        <div v-for="x in glyphEffects"
+        <div v-if="showGlyphEffectDots" v-for="x in glyphEffects"
           :style="glyphEffectIcon(x)"/>
         <glyph-tooltip v-if="hasTooltip"
                        v-show="isCurrentTooltip"

--- a/javascripts/core/app/modal.js
+++ b/javascripts/core/app/modal.js
@@ -39,6 +39,7 @@ Modal.shortcuts = new Modal("modal-shortcuts");
 Modal.animationOptions = new Modal("modal-animation-options");
 Modal.confirmationOptions = new Modal("modal-confirmation-options");
 Modal.infoDisplayOptions = new Modal("modal-info-display-options");
+Modal.miscellaneousOptions = new Modal("modal-miscellaneous-options");
 Modal.loadGame = new Modal("modal-load-game");
 Modal.uiChoice = new Modal("modal-ui-choice");
 Modal.import = new Modal("modal-import");

--- a/javascripts/core/player.js
+++ b/javascripts/core/player.js
@@ -478,6 +478,7 @@ let player = {
     updateRate: 33,
     newUI: true,
     offlineProgress: true,
+    showGlyphEffectDots: true,
     showHintText: {
       achievements: false,
       challenges: false,


### PR DESCRIPTION
Also move offline progress to miscellaneous options because outside of testing it seems rather niche.

Glyph dots are clearly a good way of conveying information, but I find them slightly aesthetically displeasing (probably just because I've spent months without them). Thus, this option. Since options is getting big and there will probably be more, I created miscellaneous options, and since the glyph dots option only shows up on reality and having empty miscellaneous options seems weird, I made offline progress a miscellaneous option. Other suggestions for miscellaneous options are appreciated (either existing options or new ones). I can also make offline progress a main-page option again if that's desired.