### PR TITLE
Make auto-achievement toggle not display in first reality

### DIFF
--- a/javascripts/components/achievements/normal/normal-achievements-tab.js
+++ b/javascripts/components/achievements/normal/normal-achievements-tab.js
@@ -25,7 +25,7 @@ Vue.component("normal-achievements-tab", {
     update() {
       this.achievementPower = Achievements.power;
       this.achCountdown = Achievements.timeToNextAutoAchieve() / getGameSpeedupFactor();
-      this.showAutoAchieve = !Perk.achievementRowGroup6.isBought;
+      this.showAutoAchieve = player.realities > 0 && !Perk.achievementRowGroup6.isBought;
       this.isAutoAchieveActive = player.reality.autoAchieve;
       this.isCancer = player.secretUnlocks.cancerAchievements;
     },


### PR DESCRIPTION
What it sounds like. I have basically no opinion on whether auto-achievement should display if all achievements have been earned after first reality, but it definitely shouldn't display in first reality.