### PR TITLE
Make effarigachievement pow rather than mult

### DIFF
--- a/javascripts/core/achievements/normal-achievement.js
+++ b/javascripts/core/achievements/normal-achievement.js
@@ -132,7 +132,7 @@ const Achievements = {
     const unlockedRows = Achievements.allRows
       .countWhere(row => row.every(ach => ach.isUnlocked));
     const basePower = Math.pow(1.25, unlockedRows) * Math.pow(1.03, Achievements.effectiveCount);
-    return basePower * getAdjustedGlyphEffect("effarigachievement");
+    return Math.pow(basePower, getAdjustedGlyphEffect("effarigachievement"));
   }),
 
   get power() {

--- a/javascripts/core/secret-formula/infinity/break-infinity-upgrades.js
+++ b/javascripts/core/secret-formula/infinity/break-infinity-upgrades.js
@@ -47,13 +47,7 @@ GameDatabase.infinity.breakUpgrades = (function() {
       id: "achievementMult",
       cost: 1e6,
       description: "Normal dimensions gain a multiplier based on achievements completed",
-      effect: () => Math.max(
-        Math.pow(
-          Math.pow((Achievements.effectiveCount - 30), 3) / 40,
-          getAdjustedGlyphEffect("effarigachievement")
-        ),
-        1
-      ),
+      effect: () => Math.max(Math.pow((Achievements.effectiveCount - 30), 3) / 40, 1),
       formatEffect: value => formatX(value, 2, 2)
     },
     slowestChallengeMult: {


### PR DESCRIPTION
This change is in accordance with the in-game description of the effect. As it is in master right now, the effect is extremely weak.

Also this PR makes effarigachievement not affect the break infinity upgrade based on achievements, since I don't think that's the clearest interpretation of the glyph effect (it doesn't say "all achievement multipliers"), and also that part of the effect is basically completely useless. If other people want then I can revert this part.

Balance effects: This might make post-Effarig up to V a bit easier, but probably mostly in terms of being able to use slightly more Effarig glyphs (specifically, those with effarigachievement and other good effects) and thus needing to grind less (it also might make V unlock dilation requirement somewhat easier due to more TP from a reality upgrade). I'm not sure what effect it has during and after V; my guess is "not gamebreaking, but easily noticeable due to the 1e5x or more gamespeed". Note that the actual dimension multipliers from achievements are basically insignificant.