### PR TITLE
Make switching between commas and notation on exponents actually work

### DIFF
--- a/javascripts/components/options/options-button-grid.js
+++ b/javascripts/components/options/options-button-grid.js
@@ -54,6 +54,7 @@ Vue.component("options-button-grid", {
     },
     commas(newValue) {
       player.options.commas = newValue;
+      ADNotations.Settings.exponentCommas.show = newValue;
     },
     offlineProgress(newValue) {
       player.options.offlineProgress = newValue;

--- a/javascripts/core/storage/storage.js
+++ b/javascripts/core/storage/storage.js
@@ -134,6 +134,7 @@ const GameStorage = {
     Enslaved.boostReality = false;
     Theme.set(player.options.theme);
     Notations.find(player.options.notation).setAsCurrent();
+    ADNotations.Settings.exponentCommas.show = player.options.commas;
 
     EventHub.dispatch(GAME_EVENT.GAME_LOAD);
     AutomatorBackend.initializeFromSave();


### PR DESCRIPTION
Right now, switching between commas and notation on exponents apparently does nothing, because player.options.commas isn't used anywhere. This PR makes it work. I doubt that this is the best way to make it work, though.