### PR TITLE
Add glyph sac requirement of 1e32 to V unlock

### DIFF
--- a/javascripts/components/celestials/subtabs/v-tab.js
+++ b/javascripts/components/celestials/subtabs/v-tab.js
@@ -6,6 +6,7 @@ Vue.component("v-tab", {
       mainUnlock: false,
       totalUnlocks: 0,
       realities: 0,
+      totalGlyphSacrifice: 0,
       infinities: new Decimal(0),
       eternities: new Decimal(0),
       dilatedTime: new Decimal(0),
@@ -24,6 +25,7 @@ Vue.component("v-tab", {
       this.mainUnlock = V.has(V_UNLOCKS.V_ACHIEVEMENT_UNLOCK);
       this.totalUnlocks = V.spaceTheorems;
       this.realities = player.realities;
+      this.totalGlyphSacrifice = Object.values(player.reality.glyphs.sac).sum();
       this.infinities.copyFrom(player.infinitied);
       this.eternities.copyFrom(player.eternities);
       this.dilatedTime.copyFrom(player.dilation.dilatedTime);
@@ -115,6 +117,9 @@ Vue.component("v-tab", {
         {{ format(dilatedTime, 2, 0) }} / {{ format(db.mainUnlock.dilatedTime, 2, 0) }} dilated time
         <br>
         {{ format(replicanti, 2, 0) }} / {{ format(db.mainUnlock.replicanti, 2, 0) }} replicanti
+        <br>
+        {{ format(totalGlyphSacrifice, 2, 0) }} / {{ format(db.mainUnlock.totalGlyphSacrifice, 2, 0) }}
+        total glyph sacrifice power
         <br>
         <div class="l-v-milestones-grid__row">
           <div class="o-v-milestone">

--- a/javascripts/core/celestials/V.js
+++ b/javascripts/core/celestials/V.js
@@ -103,6 +103,7 @@ const V_UNLOCKS = {
     requirement: () => {
       const db = GameDatabase.celestials.v.mainUnlock;
       if (player.realities < db.realities) return false;
+      if (Object.values(player.reality.glyphs.sac).sum() < db.totalGlyphSacrifice) return false;
       if (player.eternities.lt(db.eternities)) return false;
       if (player.infinitied.plus(player.infinitiedBank).lt(db.infinities)) return false;
       if (player.dilation.dilatedTime.lt(db.dilatedTime)) return false;

--- a/javascripts/core/secret-formula/celestials/v.js
+++ b/javascripts/core/secret-formula/celestials/v.js
@@ -8,11 +8,12 @@ const V_REDUCTION_MODE = {
 GameDatabase.celestials.v = {
   mainUnlock: {
     realities: 10000,
+    totalGlyphSacrifice: 1e32,
     eternities: 1e70,
     infinities: 1e160,
     dilatedTime: new Decimal("1e320"),
     replicanti: new Decimal("1e320000"),
-    rm: 1e60
+    rm: 1e60,
   },
   runUnlocks: [
     {

--- a/javascripts/core/secret-formula/h2p.js
+++ b/javascripts/core/secret-formula/h2p.js
@@ -918,9 +918,10 @@ which requires you to get 800 Antimatter Galaxies without buying 8th Dimensions 
 <br>
 <br>
 After being unlocked from the achievement, you are met with another set of requirements to fully unlock V.
-You must have completed ${formatInt(GameDatabase.celestials.v.mainUnlock.realities)} Realities and have
-${format(GameDatabase.celestials.v.mainUnlock.rm)} RM (which is not spent). Additionally you need to reach 
-${format(GameDatabase.celestials.v.mainUnlock.eternities)} Eternities,
+You must have completed ${formatInt(GameDatabase.celestials.v.mainUnlock.realities)} Realities, have
+${format(GameDatabase.celestials.v.mainUnlock.rm)} RM (which is not spent), and have
+${format(GameDatabase.celestials.v.mainUnlock.totalGlyphSacrifice)} total glyph sacrifice power.
+Additionally you need to reach  ${format(GameDatabase.celestials.v.mainUnlock.eternities)} Eternities,
 ${format(GameDatabase.celestials.v.mainUnlock.infinities)} Infinities,
 ${format(GameDatabase.celestials.v.mainUnlock.dilatedTime)} Dilated Time, and 
 ${format(GameDatabase.celestials.v.mainUnlock.replicanti)} Replicanti, all in the same reality.


### PR DESCRIPTION
I think we decided this was a good idea to remind people to do Teresa again. Not sure if I should create a new `player.reality.glyphs.sac.total` or something like that (maybe a function)?