### PR TITLE
Fix achievements 52 and 53, fixes #1100

### DIFF
--- a/javascripts/core/secret-formula/achievements/normal-achievements.js
+++ b/javascripts/core/secret-formula/achievements/normal-achievements.js
@@ -66,7 +66,8 @@ GameDatabase.achievements.normal = [
     id: 22,
     name: "Fake News",
     tooltip: () => `Encounter ${formatInt(50)} different news messages.`,
-    checkRequirement: () => player.news.size >= 50
+    checkRequirement: () => player.news.size >= 50,
+    checkEvent: GAME_EVENT.REALITY_RESET_AFTER
   },
   {
     id: 23,
@@ -257,7 +258,8 @@ GameDatabase.achievements.normal = [
     name: "Age of Automation",
     tooltip: "Max dimension and tickspeed autobuyers.",
     checkRequirement: () => Autobuyers.upgradeable
-      .countWhere(a => a.hasMaxedInterval) >= 9
+      .countWhere(a => a.hasMaxedInterval) >= 9,
+    checkEvent: GAME_EVENT.REALITY_RESET_AFTER
   },
   {
     id: 53,
@@ -266,7 +268,8 @@ GameDatabase.achievements.normal = [
     checkRequirement: () => Autobuyers.upgradeable.countWhere(a => !a.hasMaxedInterval) === 0 &&
       Autobuyer.galaxy.hasMaxedInterval &&
       Autobuyer.dimboost.hasMaxedInterval &&
-      Autobuyer.bigCrunch.hasMaxedInterval
+      Autobuyer.bigCrunch.hasMaxedInterval,
+    checkEvent: GAME_EVENT.REALITY_RESET_AFTER
   },
   {
     id: 54,


### PR DESCRIPTION
Also fix a small bug wherein achievement 22 (Fake News) is only awarded in a new reality when the current news ticker finishes and a new one is chosen (instead award it immediately).

This is a small bugfix, so probably if anyone but me thinks it seems right, it probably is and they can just merge without waiting for the other's review.