### PR TITLE
Make two other news messages that should give "Real News" give it

### DIFF
--- a/javascripts/core/secret-formula/news.js
+++ b/javascripts/core/secret-formula/news.js
@@ -617,7 +617,10 @@ GameDatabase.news = [
   },
   {
     id: "a130",
-    text: "Click this to unlock that one secret achievement."
+    text: "Click this to unlock that one secret achievement.",
+    // This next line is needed for this news ticker to unlock
+    // the secret achievement.
+    onClick: () => undefined
   },
   {
     id: "a131",
@@ -847,8 +850,9 @@ GameDatabase.news = [
   {
     id: "a173",
     text:
-      "<span style='animation: a-game-header__antimatter--glow 3s infinite' onclick='bigCrunchAnimation()'>This " +
-      "text is made of antimatter. Do not touch or else the universe will collapse.</span>"
+      "<span style='animation: a-game-header__antimatter--glow 3s infinite'>This " +
+      "text is made of antimatter. Do not touch or else the universe will collapse.</span>",
+    onClick: () => bigCrunchAnimation()
   },
   {
     id: "a174",


### PR DESCRIPTION
The message that originally gave "Real News" was no longer giving it. Also another message that had onclick defined in the message wasn't giving it either.

This doesn't handle the message with a discord link or the one with an audio button you can press, but those are edge cases and it's unclear which way they should go anyway. If desired I can manually add code in those two places that gives "Real News", but I'm not sure how to do this extensibly.