### PR TITLE
Make r52 and r53 not unlock until all the relevant autobuyers unlock

### DIFF
--- a/javascripts/core/challenge.js
+++ b/javascripts/core/challenge.js
@@ -87,6 +87,11 @@ class NormalChallengeState extends GameMechanicState {
   complete() {
     // eslint-disable-next-line no-bitwise
     player.challenge.normal.completedBits |= 1 << this.id;
+    // Since breaking infinity maxes even autobuyers that aren't unlocked,
+    // it's possible to get r52 or r53 from completing a challenge
+    // and thus unlocking an autobuyer.
+    Achievement(52).tryUnlock();
+    Achievement(53).tryUnlock();
   }
 
   get goal() {

--- a/javascripts/core/secret-formula/achievements/normal-achievements.js
+++ b/javascripts/core/secret-formula/achievements/normal-achievements.js
@@ -258,17 +258,16 @@ GameDatabase.achievements.normal = [
     name: "Age of Automation",
     tooltip: "Max dimension and tickspeed autobuyers.",
     checkRequirement: () => Autobuyers.upgradeable
-      .countWhere(a => a.hasMaxedInterval) >= 9,
+      .countWhere(a => a.isUnlocked && a.hasMaxedInterval) >= 9,
     checkEvent: GAME_EVENT.REALITY_RESET_AFTER
   },
   {
     id: 53,
     name: "Definitely not worth it",
     tooltip: "Max all the autobuyers.",
-    checkRequirement: () => Autobuyers.upgradeable.countWhere(a => !a.hasMaxedInterval) === 0 &&
-      Autobuyer.galaxy.hasMaxedInterval &&
-      Autobuyer.dimboost.hasMaxedInterval &&
-      Autobuyer.bigCrunch.hasMaxedInterval,
+    checkRequirement: () => Autobuyers.upgradeable
+      .concat([Autobuyer.galaxy, Autobuyer.dimboost, Autobuyer.bigCrunch])
+      .countWhere(a => a.isUnlocked && a.hasMaxedInterval) >= 12,
     checkEvent: GAME_EVENT.REALITY_RESET_AFTER
   },
   {


### PR DESCRIPTION
Fixes #1106. Non-unlocked autobuyers are still maxed when infinity is broken. Omsi, if you feel like more people should look at this, feel free to add additional reviewers.