### PR TITLE
Make New UI blackhole and reality upgrade autobuyers fit

### DIFF
--- a/stylesheets/new-ui-styles.css
+++ b/stylesheets/new-ui-styles.css
@@ -629,6 +629,12 @@ body.t-normal {
   margin: 0.5rem;
 }
 
+.l--spoon-btn-group__little-spoon-reality-btn {
+  width: 15.6rem;
+  align-self: center;
+  margin-top: -0.2rem;
+}
+
 .resource-eternity-canreset > div {
   height: 100%;
 }


### PR DESCRIPTION
This stops them from being wider than the buttons above them and making the whole UI upgrade. Reality upgrade IDs are still partially hidden for some reason but that's more minor (and also I have no clue why it's happening).