### PR TITLE
Make the cost of the 2x IP multiplier be a power of 1e10 above 1e3e6

### DIFF
--- a/javascripts/core/secret-formula/infinity/infinity-upgrades.js
+++ b/javascripts/core/secret-formula/infinity/infinity-upgrades.js
@@ -200,9 +200,7 @@ GameDatabase.infinity.upgrades = (function() {
     ipMult: {
       cost: () => player.infMultCost,
       costCap: new Decimal("1e6000000"),
-      // If the cost increase threshold is 1e2999999, the costs go
-      // 1e2999999, 1e3000000, 1e3000010, etc., which is nicer than the alternative.
-      costIncreaseThreshold: new Decimal("1e2999999"),
+      costIncreaseThreshold: new Decimal("1e3000000"),
       description: () => `Multiply Infinity Points from all sources by ${formatInt(2)}`,
       effect: () => player.infMult,
       cap: () => Effarig.eternityCap || new Decimal("1e1000000"),


### PR DESCRIPTION
Previously it was 10x more than a power of 1e10. This should be insignificant balance-wise; it's mostly just for appearances. The comment could perhaps be improved.