### PR TITLE
Add back infinity glyph sacrifice but make it far weaker

### DIFF
--- a/javascripts/core/dimensions/infinity-dimension.js
+++ b/javascripts/core/dimensions/infinity-dimension.js
@@ -223,7 +223,7 @@ class InfinityDimensionState extends DimensionState {
   }
 
   get powerMultiplier() {
-    return this._powerMultiplier;
+    return new Decimal(this._powerMultiplier).timesEffectsOf(this._tier === 8 ? GlyphSacrifice.infinity : null);
   }
 
   get purchases() {

--- a/javascripts/core/secret-formula/reality/glyph-sacrifices.js
+++ b/javascripts/core/secret-formula/reality/glyph-sacrifices.js
@@ -11,7 +11,7 @@ GameDatabase.reality.glyphSacrifice = [
     }
   }, {
     id: "infinity",
-    effect: () => 1 + Math.pow(player.reality.glyphs.sac.infinity, 0.2) / 100,
+    effect: () => Math.pow(1 + Math.pow(player.reality.glyphs.sac.infinity, 0.2) / 100, 1 / 4),
     description: amount => `${formatX(amount, 2, 2)} bigger multiplier when buying 8th Infinity Dimension.`
   }, {
     id: "time",


### PR DESCRIPTION
Apparently it hasn't been applying since https://github.com/IvarK/HahaSlabWontGetHere/commit/539d81c9d387209aaf731698ac5e58122ae67c76. This is about 2x RM at PP shop, 8x RM at 1e60 RM V unlock wall, 2 OoM RM at ~1e80 RM in mid-late V, and 10 OoM RM at ~1e200 RM in Ra (none of these account for rupg/blackhole purchases, which may raise the given numbers to something in the ^1.5 to ^2 range). For more detailed stats on the effects ask me on discord, or as a comment to this PR I guess.