### PR TITLE
Reverse the order of dilation and power effects on ID

### DIFF
--- a/javascripts/core/dimensions/infinity-dimension.js
+++ b/javascripts/core/dimensions/infinity-dimension.js
@@ -193,6 +193,8 @@ class InfinityDimensionState extends DimensionState {
       );
     mult = mult.times(Decimal.pow(this.powerMultiplier, Math.floor(this.baseAmount / 10)));
 
+    mult = mult.clampMin(0);
+
     mult = mult.pow(getAdjustedGlyphEffect("infinitypow"));
 
     mult = mult.pow(getAdjustedGlyphEffect("effarigdimensions"));
@@ -200,8 +202,6 @@ class InfinityDimensionState extends DimensionState {
     mult = mult.pow(getAdjustedGlyphEffect("curseddimensions"));
 
     mult = mult.powEffectOf(AlchemyResource.infinity);
-
-    mult = mult.clampMin(0);
 
     if (player.dilation.active) {
       mult = dilatedValueOf(mult);


### PR DESCRIPTION
I can't think of anything this affects significantly (first dilation effect is laughably small, I did matterception without any ID pow effects, Enslaved only dilates ND mults by default). I think this is technically a nerf.