### PR TITLE
Add confirmation for harsh auto clean

### DIFF
--- a/javascripts/components/modals/options/modal-confirmation-options.js
+++ b/javascripts/components/modals/options/modal-confirmation-options.js
@@ -9,6 +9,7 @@ Vue.component("modal-confirmation-options", {
       eternity: false,
       dilation: false,
       reality: false,
+      harshAutoClean: false,
       glyphReplace: false,
       glyphSacrifice: false,
       glyphSacrificeUnlocked: false,
@@ -34,6 +35,9 @@ Vue.component("modal-confirmation-options", {
     reality(newValue) {
       player.options.confirmations.reality = newValue;
     },
+    harshAutoClean(newValue) {
+      player.options.confirmations.harshAutoClean = newValue;
+    },
     glyphReplace(newValue) {
       player.options.confirmations.glyphReplace = newValue;
     },
@@ -55,6 +59,7 @@ Vue.component("modal-confirmation-options", {
       this.eternity = options.eternity;
       this.dilation = options.dilation;
       this.reality = options.reality;
+      this.harshAutoClean = options.harshAutoClean;
       this.glyphReplace = options.glyphReplace;
       this.glyphSacrifice = options.glyphSacrifice;
       this.glyphSacrificeUnlocked = GlyphSacrificeHandler.canSacrifice;
@@ -71,6 +76,7 @@ Vue.component("modal-confirmation-options", {
       <on-off-button v-if="eternityUnlocked" v-model="eternity" text="Eternity:"/>
       <on-off-button v-if="dilationUnlocked" v-model="dilation" text="Dilation:"/>
       <on-off-button v-if="realityUnlocked" v-model="reality" text="Reality:"/>
+      <on-off-button v-if="realityUnlocked" v-model="harshAutoClean" text="Harsh auto clean:"/>
       <on-off-button v-if="realityUnlocked" v-model="glyphReplace" text="Glyph replace:"/>
       <on-off-button v-if="glyphSacrificeUnlocked" v-model="glyphSacrifice" text="Glyph sacrifice:"/>
       <on-off-button v-if="glyphTrashUnlocked" v-model="glyphTrash" text="Glyph trash:"/>

--- a/javascripts/core/player.js
+++ b/javascripts/core/player.js
@@ -539,6 +539,7 @@ let player = {
       eternity: true,
       dilation: true,
       reality: true,
+      harshAutoClean: true,
       glyphReplace: true,
       glyphSacrifice: true,
       glyphTrash: true,

--- a/javascripts/core/rm.js
+++ b/javascripts/core/rm.js
@@ -718,6 +718,15 @@ const Glyphs = {
         "Are you sure you want to do this?")) {
       return;
     }
+    // If the player has unlocked sacrifice (so has not gotten the above warning) and auto clean could remove
+    // useful glyphs, we warn them.
+    if (GlyphSacrificeHandler.canSacrifice && thresholdOverride !== undefined &&
+      player.options.confirmations.harshAutoClean &&
+      // eslint-disable-next-line prefer-template
+      !confirm("This could delete glyphs in your inventory that are good enough that you might want to use them " +
+        "later. Are you sure you want to do this?")) {
+      return;
+    }
     // We look in backwards order so that later glyphs get cleaned up first
     for (let inventoryIndex = this.totalSlots - 1; inventoryIndex >= this.protectedSlots; --inventoryIndex) {
       const glyph = this.inventory[inventoryIndex];


### PR DESCRIPTION
Also applies to deleting all unprotected glyphs. I think that if we don't do this, at some point someone (probably me) is going to accidentally click one of those buttons and complain.