### PR TITLE
Decrease Lingustically Expand requirement back to 3

### DIFF
--- a/javascripts/core/secret-formula/reality/reality-upgrades.js
+++ b/javascripts/core/secret-formula/reality/reality-upgrades.js
@@ -100,14 +100,14 @@ GameDatabase.reality.upgrades = (function() {
       name: "Linguistically Expand",
       id: 9,
       cost: 15,
-      requirement: () => `Reality using only a single level ${formatInt(4)}+ glyph.`,
+      requirement: () => `Reality using only a single level ${formatInt(3)}+ glyph.`,
       hasFailed: () => {
         const invalidEquippedGlyphs = Glyphs.activeList.length > 1 ||
-          (Glyphs.activeList.length === 1 && Glyphs.activeList[0].level < 4);
-        const hasValidGlyphInInventory = Glyphs.inventory.countWhere(g => g && g.level >= 4) > 0;
+          (Glyphs.activeList.length === 1 && Glyphs.activeList[0].level < 3);
+        const hasValidGlyphInInventory = Glyphs.inventory.countWhere(g => g && g.level >= 3) > 0;
         return invalidEquippedGlyphs || (Glyphs.activeList.length === 0 && !hasValidGlyphInInventory);
       },
-      checkRequirement: () => Glyphs.activeList.length === 1 && Glyphs.activeList[0].level >= 4,
+      checkRequirement: () => Glyphs.activeList.length === 1 && Glyphs.activeList[0].level >= 3,
       checkEvent: GAME_EVENT.REALITY_RESET_BEFORE,
       description: "Gain another glyph slot",
       effect: () => 1


### PR DESCRIPTION
Even with the previous system, I got it with most of 3rd row complete and both glyph perks, Hevi hadn't yet gotten it with most of 3rd row complete and couldn't get it with an overnight run and a repl with repl speed + glyph level, Spanosa got a glyph perk before getting it, and Sere happened to get a very good repl glyph for it. I think lowering it back down is a good idea. It's probably still the hardest upgrade in the row.