### PR TITLE
Fix bug potentially causing double-click to spend more PP than possessed

### DIFF
--- a/javascripts/components/celestials/subtabs/v-tab.js
+++ b/javascripts/components/celestials/subtabs/v-tab.js
@@ -58,7 +58,7 @@ Vue.component("v-tab", {
         : milestone.reward;
     },
     reduceGoals(hex) {
-      if (this.pp < hex.reductionCost) return;
+      if (player.reality.pp < hex.reductionCost) return;
       player.reality.pp -= hex.reductionCost;
       const steps = hex.config.reductionStepSize ? hex.config.reductionStepSize : 1;
       player.celestials.v.goalReductionSteps[hex.id] += steps;


### PR DESCRIPTION
I couldn't actually reproduce the bug, but theoretically if the component didn't update between two clicks, the bug would've happened (because the first purchase didn't change `this.pp`). This commit should fix that.