### PR TITLE
Fix reality glyph bug

### DIFF
--- a/javascripts/core/rm.js
+++ b/javascripts/core/rm.js
@@ -560,7 +560,9 @@ const Glyphs = {
       this.levelBoost = 0;
       return;
     }
-    this.levelBoost = getAdjustedGlyphEffect("realityglyphlevel");
+    // The cache at this point may not be correct yet (if we're importing a save),
+    // so we use the uncached value.
+    this.levelBoost = getAdjustedGlyphEffectUncached("realityglyphlevel");
   },
   moveToSlot(glyph, targetSlot) {
     if (this.inventory[targetSlot] === null) this.moveToEmpty(glyph, targetSlot);


### PR DESCRIPTION
This commit fixes the following bug: when you reset the game and then import a save with a reality glyph equipped, the basic glyph level increase effect is not taken into account. Some such saves: https://gist.github.com/dan-simon/967fc7a908bfef5f3b559c8d9a563b0a