### PR TITLE
Handle total time played and "Don't you dare sleep" in offline progress

### DIFF
--- a/javascripts/components/statistics/statistics-tab.js
+++ b/javascripts/components/statistics/statistics-tab.js
@@ -43,7 +43,7 @@ Vue.component("statistics-tab", {
   methods: {
     update() {
       this.totalAntimatter.copyFrom(player.totalAntimatter);
-      this.realTimePlayed.setFrom(Date.now() - player.gameCreatedTime);
+      this.realTimePlayed.setFrom(player.realTimePlayed);
       this.newsMessagesSeen = player.news.size;
       const progress = PlayerProgress.current;
       const isInfinityUnlocked = progress.isInfinityUnlocked;

--- a/javascripts/core/secret-formula/news.js
+++ b/javascripts/core/secret-formula/news.js
@@ -1247,7 +1247,7 @@ GameDatabase.news = [
     id: "a230",
     get text() {
       return "You started playing this game nearly " +
-        `${TimeSpan.fromMilliseconds(player.realTimePlayed).toString()} ago. Thank you for playing!`;
+        `${TimeSpan.fromMilliseconds(Date.now() - player.gameCreatedTime).toString()} ago. Thank you for playing!`;
     },
     dynamic: true
   },
@@ -2334,7 +2334,7 @@ GameDatabase.news = [
   },
   {
     id: "l60",
-    get text() { 
+    get text() {
       return `Breaking News! Time Shard mine collapses! ${Math.floor(20 + Math.random() * 236)} miners trapped inside!`;
     },
     get unlocked() { return PlayerProgress.eternityUnlocked(); }
@@ -2396,7 +2396,7 @@ GameDatabase.news = [
   },
   {
     id: "l68",
-    get text() { 
+    get text() {
       let protestText = "";
       if (InfinityChallenge(4).isRunning)
         protestText =

--- a/javascripts/core/storage/storage.js
+++ b/javascripts/core/storage/storage.js
@@ -166,10 +166,8 @@ const GameStorage = {
         this.postLoadStuff();
       }
     } else {
-      // This is adjusted so time played doesn't count the offline time.
-      player.gameCreatedTime += Date.now() - player.lastUpdate;
       // Try to unlock "Don't you dare sleep" (usually this check only happens
-      // during a game tick,, which makes the achievement impossible to get
+      // during a game tick, which makes the achievement impossible to get
       // with offline progress off)
       Achievement(35).tryUnlock();
       player.lastUpdate = Date.now();


### PR DESCRIPTION
Fixes #1492, fixes #1485 by making game time played the same as real time played pre-EC12, fixes a bug where you couldn't get "Don't you dare sleep" with offline progress off