### PR TITLE
Refactor Secret Achievement UI code

### DIFF
--- a/javascripts/components/achievements/secret/secret-achievement-row.js
+++ b/javascripts/components/achievements/secret/secret-achievement-row.js
@@ -2,7 +2,7 @@
 
 Vue.component("secret-achievement-row", {
   props: {
-    row: Number
+    row: Array
   },
   data() {
     return {
@@ -17,23 +17,17 @@ Vue.component("secret-achievement-row", {
       };
     }
   },
-  created() {
-    this.on$(GAME_EVENT.ACHIEVEMENT_UNLOCKED, this.updateState);
-    this.updateState();
-  },
   methods: {
-    updateState() {
-      const unlockState = Array.range(1, 8).map(i => SecretAchievement(this.row * 10 + i).isUnlocked);
-      this.isCompleted = !unlockState.includes(false);
+    update() {
+      this.isCompleted = this.row.every(a => a.isUnlocked);
     }
   },
   template:
     `<div :class="classObject">
       <secret-achievement
-        v-for="column in 8"
-        :key="column"
-        :row="row"
-        :column="column"
+        v-for="(achievement, i) in row"
+        :key="i"
+        :achievement="achievement"
         class="l-achievement-grid__cell"
       />
     </div>`

--- a/javascripts/components/achievements/secret/secret-achievement.js
+++ b/javascripts/components/achievements/secret/secret-achievement.js
@@ -2,8 +2,7 @@
 
 Vue.component("secret-achievement", {
   props: {
-    row: Number,
-    column: Number
+    achievement: Object
   },
   data() {
     return {
@@ -12,17 +11,17 @@ Vue.component("secret-achievement", {
     };
   },
   computed: {
-    achId() {
-      return this.row * 10 + this.column;
+    id() {
+      return this.achievement.id;
     },
-    achievement() {
-      return SecretAchievement(this.achId);
+    config() {
+      return this.achievement.config;
     },
     styleObject() {
-      if (this.isUnlocked) {
-        return { "background-position": `-${(this.column - 1) * 104}px -${(this.row - 1) * 104}px` };
+      return this.isUnlocked ? {
+        "background-position": `-${(this.achievement.column - 1) * 104}px -${(this.achievement.row - 1) * 104}px`
       }
-      return {};
+      : {};
     },
     classObject() {
       return {
@@ -44,17 +43,20 @@ Vue.component("secret-achievement", {
       };
     },
   },
-  created() {
-    this.on$(GAME_EVENT.ACHIEVEMENT_UNLOCKED, this.updateState);
-    this.updateState();
-  },
   methods: {
-    updateState() {
+    update() {
       this.isUnlocked = this.achievement.isUnlocked;
       this.showUnlockState = player.options.showHintText.achievementUnlockStates;
     },
+    onMouseEnter() {
+      clearTimeout(this.mouseOverInterval);
+      this.isMouseOver = true;
+    },
+    onMouseLeave() {
+      this.mouseOverInterval = setTimeout(() => this.isMouseOver = false, 500);
+    },
     onClick() {
-      if (this.achId === 11 && !this.isUnlocked) {
+      if (this.id === 11 && !this.isUnlocked) {
         SecretAchievement(11).unlock();
       }
     }
@@ -63,12 +65,15 @@ Vue.component("secret-achievement", {
     `<div
       :class="classObject"
       :style="styleObject"
-      @click="onClick">
-      <hint-text type="achievements" class="l-hint-text--achievement">S{{row}}{{column}}</hint-text>
+      @click="onClick"
+      @mouseenter="onMouseEnter"
+      @mouseleave="onMouseLeave"
+      >
+      <hint-text type="achievements" class="l-hint-text--achievement">S{{ id }}</hint-text>
       <div class="o-achievement__tooltip">
-        <div class="o-achievement__tooltip__name">{{ this.achievement.config.name }} ({{ achId }})</div>
+        <div class="o-achievement__tooltip__name">{{ config.name }} (S{{ id }})</div>
         <div v-if="this.isUnlocked" class="o-achievement__tooltip__description">
-          {{ this.achievement.config.description }}
+          {{ config.description }}
         </div>
       </div>
       <div v-if="showUnlockState" :class="indicatorClassObject" v-html="indicator"></div>

--- a/javascripts/components/achievements/secret/secret-achievements-tab.js
+++ b/javascripts/components/achievements/secret/secret-achievements-tab.js
@@ -1,6 +1,9 @@
 "use strict";
 
 Vue.component("secret-achievements-tab", {
+  computed: {
+    rows: () => SecretAchievements.allRows,
+  },
   template:
   `<div class="l-achievements-tab">
     <div class="c-achievements-tab__header">
@@ -9,7 +12,7 @@ Vue.component("secret-achievements-tab", {
       </span>
     </div>
     <div class="l-achievement-grid">
-      <secret-achievement-row v-for="row in 4" :key="row" :row="row" />
+      <secret-achievement-row v-for="(row, i) in rows" :key="i" :row="row" />
     </div>
   </div>`
 });

--- a/javascripts/core/achievements/secret-achievement.js
+++ b/javascripts/core/achievements/secret-achievement.js
@@ -59,5 +59,14 @@ const SecretAchievements = {
   /**
    * @type {SecretAchievementState[]}
    */
-  all: SecretAchievement.index.compact()
+  all: SecretAchievement.index.compact(),
+
+  get allRows() {
+    const count = SecretAchievements.all.map(a => a.row).max();
+    return SecretAchievements.rows(1, count);
+  },
+
+  rows: (start, count) => Array.range(start, count).map(SecretAchievements.row),
+
+  row: row => Array.range(row * 10 + 1, 8).map(SecretAchievement),
 };


### PR DESCRIPTION
1) The tooltip for secret achievements vanished as soon as you moused off, fixed that to how normal achievements work.
2) Add code to SecretAchievements so it has .allRows, .rows, and .row, as that is how Normal Achievements do it.
3) Reworked a bit of code to make it the same as how Normal Achievements handle them.
4) Put the backend into `update()` instead of `updateState()` and `this.on$(GAME_EVENT.ACHIEVEMENT_UNLOCKED, this.updateState);`

Fixes #1603 (test by doing `SecretAchievement(11).lock()` while on the Secret Achievement tab)