### PR TITLE
Make Alchemy Resource backend easier to read

### DIFF
--- a/javascripts/components/celestials/subtabs/ra/alchemy-resource-info.js
+++ b/javascripts/components/celestials/subtabs/ra/alchemy-resource-info.js
@@ -52,9 +52,10 @@ Vue.component("alchemy-resource-info", {
   },
   methods: {
     update() {
-      this.amount = this.resource.amount;
-      this.isUnlocked = this.resource.isUnlocked;
-      this.unlockRequirement = this.resource.config.lockText;
+      const resource = this.resource;
+      this.amount = resource.amount;
+      this.isUnlocked = resource.isUnlocked;
+      this.unlockRequirement = resource.lockText;
       if (!this.isBaseResource) {
         this.isReactionActive = this.reaction.isActive;
         this.reactionProduction = this.reaction.production;

--- a/javascripts/components/celestials/subtabs/ra/ra-pet-level-bar.js
+++ b/javascripts/components/celestials/subtabs/ra/ra-pet-level-bar.js
@@ -67,8 +67,7 @@ Vue.component("ra-pet-level-bar", {
         case "Teresa":
           return Math.min(12, Math.floor(this.level / 2)) !== Math.min(12, Math.floor((this.level + 1) / 2));
         case "Effarig":
-          return AlchemyResources.all.filter(
-            res => parseInt(res._config.lockText.match(/\d+/gu)[0], 10) === this.level + 1).length > 0;
+          return AlchemyResources.all.filter(res => res.unlockedAt === this.level + 1).length > 0;
         case "Enslaved":
           return true;
         case "V":
@@ -78,15 +77,13 @@ Vue.component("ra-pet-level-bar", {
       }
     },
     nextScalingUpgrade() {
+      const effarigAlchemyResource = AlchemyResources.all.filter(res => res.unlockedAt === this.level + 1)[0];
       switch (this.pet.name) {
         case "Teresa":
           return "You can charge an additional Infinity Upgrade";
         case "Effarig":
-          return `Unlock the ${AlchemyResources.all.filter(
-            res => parseInt(res._config.lockText.match(/\d+/gu)[0], 10) === this.level + 1
-          )[0]._config.name} resource in Glyph Alchemy, which ${AlchemyResources.all.filter(
-            res => parseInt(res._config.lockText.match(/\d+/gu)[0], 10) === this.level + 1
-          )[0]._config.description}`;
+          return `Unlock the ${effarigAlchemyResource.name} resource in Glyph Alchemy, which
+          ${effarigAlchemyResource.description}`;
         case "Enslaved":
           return `+${formatFloat(0.01, 2)} to stored game time power,
             and you can store an additional hour of real time`;

--- a/javascripts/core/celestials/ra/alchemy.js
+++ b/javascripts/core/celestials/ra/alchemy.js
@@ -45,8 +45,20 @@ class AlchemyResourceState extends GameMechanicState {
     this.config.flow = value;
   }
 
+  get unlockedWith() {
+    return Ra.pets.effarig;
+  }
+
+  get unlockedAt() {
+    return this.config.unlockedAt;
+  }
+
   get isUnlocked() {
-    return this.config.isUnlocked();
+    return this.unlockedWith.level >= this.unlockedAt;
+  }
+
+  get lockText() {
+    return `${this.unlockedWith.name} Level ${this.unlockedAt}`;
   }
 
   get isCustomEffect() {

--- a/javascripts/core/secret-formula/celestials/alchemy.js
+++ b/javascripts/core/secret-formula/celestials/alchemy.js
@@ -10,8 +10,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => 1 + amount / 200000,
       tier: 1,
       uiOrder: 1,
-      isUnlocked: () => Ra.pets.effarig.level >= 2,
-      lockText: "Effarig Level 2",
+      unlockedAt: 2,
       description: "provides a multiplier to Antimatter Dimensions",
       formatEffect: value => `Antimatter Dimension multipliers ${formatPow(value, 4, 4)}`
     },
@@ -22,8 +21,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => 1 + amount / 200000,
       tier: 1,
       uiOrder: 2,
-      isUnlocked: () => Ra.pets.effarig.level >= 3,
-      lockText: "Effarig Level 3",
+      unlockedAt: 3,
       description: "provides a multiplier to Infinity Dimensions",
       formatEffect: value => `Infinity Dimension multipliers ${formatPow(value, 4, 4)}`
     },
@@ -34,8 +32,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => 1 + amount / 200000,
       tier: 1,
       uiOrder: 3,
-      isUnlocked: () => Ra.pets.effarig.level >= 4,
-      lockText: "Effarig Level 4",
+      unlockedAt: 4,
       description: "provides a multiplier to Time Dimensions",
       formatEffect: value => `Time Dimension multipliers ${formatPow(value, 4, 4)}`
     },
@@ -46,8 +43,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => Decimal.pow10(amount / 1000),
       tier: 1,
       uiOrder: 4,
-      isUnlocked: () => Ra.pets.effarig.level >= 5,
-      lockText: "Effarig Level 5",
+      unlockedAt: 5,
       description: `increases Replication Speed`,
       formatEffect: value => `Replication speed is increased by ${formatX(value, 2, 2)}`
     },
@@ -58,8 +54,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => Decimal.pow10(amount / 2000),
       tier: 1,
       uiOrder: 5,
-      isUnlocked: () => Ra.pets.effarig.level >= 6,
-      lockText: "Effarig Level 6",
+      unlockedAt: 6,
       description: "increases Dilated Time production",
       formatEffect: value => `Dilated Time production is increased by ${formatX(value, 2, 2)}`
     },
@@ -72,8 +67,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => 1 + 0.2 / (1 + amount / 20000),
       tier: 2,
       uiOrder: 3,
-      isUnlocked: () => Ra.pets.effarig.level >= 8,
-      lockText: "Effarig Level 8",
+      unlockedAt: 8,
       get description() { return `reduces the slowdown per ${format(Number.MAX_VALUE, 2)} Replicanti`; },
       formatEffect: value => `Replicanti interval increases slower ${formatX(1.2, 1, 1)} ➜ ` +
         `${formatX(value, 4, 4)} per ${format(Number.MAX_VALUE, 2)}`,
@@ -95,8 +89,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => 1 + amount / 15000,
       tier: 2,
       uiOrder: 2,
-      isUnlocked: () => Ra.pets.effarig.level >= 9,
-      lockText: "Effarig Level 9",
+      unlockedAt: 9,
       description: "increases Eternity generation",
       formatEffect: value => `Eternity generation ${formatPow(value, 4, 4)}`,
       reagents: [
@@ -117,8 +110,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => Decimal.pow10(5 * amount),
       tier: 2,
       uiOrder: 1,
-      isUnlocked: () => Ra.pets.effarig.level >= 10,
-      lockText: "Effarig Level 10",
+      unlockedAt: 10,
       description: "provides a multiplier to all dimensions",
       formatEffect: value => `All Dimensions ${formatX(value)}`,
       reagents: [
@@ -139,8 +131,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => Decimal.pow10(6e9 - 3e5 * amount),
       tier: 2,
       uiOrder: 5,
-      isUnlocked: () => Ra.pets.effarig.level >= 11,
-      lockText: "Effarig Level 11",
+      unlockedAt: 11,
       description: "increases multiplier effect over a threshold",
       formatEffect: value => `All Antimatter Dimension multipliers are ${formatPow(1.05, 2, 2)}
       if they are above ${format(value)} `,
@@ -162,8 +153,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => amount / 200000,
       tier: 2,
       uiOrder: 4,
-      isUnlocked: () => Ra.pets.effarig.level >= 12,
-      lockText: "Effarig Level 12",
+      unlockedAt: 12,
       description: "increases the strength of Tachyon Galaxies based on Replicanti",
       formatEffect: value => `Tachyon Galaxies are ${formatPercents(value, 2, 2)} stronger ` +
         `per ${format("1e1000000")} Replicanti`,
@@ -187,8 +177,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => Math.pow(10, amount / 2500),
       tier: 2,
       uiOrder: 3.5,
-      isUnlocked: () => Ra.pets.effarig.level >= 7,
-      lockText: "Effarig Level 7",
+      unlockedAt: 7,
       description: "increases Relic Shard gain",
       formatEffect: value => `Relic Shard gain is multiplied ${formatX(value, 2, 2)}`
     },
@@ -199,8 +188,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => Math.clampMax(0.3 + Math.sqrt(amount / 15000), 1),
       tier: 3,
       uiOrder: 2,
-      isUnlocked: () => Ra.pets.effarig.level >= 13,
-      lockText: "Effarig Level 13",
+      unlockedAt: 13,
       description: "increases the effectiveness of Alchemy Reactions",
       formatEffect(value) {
         const baseEffect = `Alchemy reaction efficiency ${formatPercents(0.3)} ➜ ${formatPercents(value, 2, 2)}`;
@@ -232,8 +220,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => 1 + amount / 125000,
       tier: 3,
       uiOrder: 3,
-      isUnlocked: () => Ra.pets.effarig.level >= 15,
-      lockText: "Effarig Level 15",
+      unlockedAt: 15,
       description: "provides a multiplier to all dimensions based on real time since unlock",
       formatEffect: value => `All Dimensions ${formatPow(Ra.momentumValue, 4, 4)}, increasing by ${format(0.002, 3, 3)}
         per real-time hour after the resource is unlocked, up to a maximum of ${formatPow(value, 4, 4)}`,
@@ -259,8 +246,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => 0.10 * Math.sqrt(amount / 10000),
       tier: 3,
       uiOrder: 4,
-      isUnlocked: () => Ra.pets.effarig.level >= 14,
-      lockText: "Effarig Level 14",
+      unlockedAt: 14,
       description: "causes refining to give all basic Alchemy Resources",
       formatEffect: value => `Refined Glyphs also give ${formatPercents(value, 2)} of their value ` +
         "to all other base resources",
@@ -284,8 +270,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => 10 * Math.pow(amount / 10000, 2),
       tier: 4,
       uiOrder: 2,
-      isUnlocked: () => Ra.pets.effarig.level >= 18,
-      lockText: "Effarig Level 18",
+      unlockedAt: 18,
       description: "multiplies Infinity Points by Replicanti",
       formatEffect: value => `Infinity Points multiplied by Replicanti${formatPow(value, 2, 3)}`,
       reagents: [
@@ -306,8 +291,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => 5 * amount,
       tier: 4,
       uiOrder: 2,
-      isUnlocked: () => Ra.pets.effarig.level >= 17,
-      lockText: "Effarig Level 17",
+      unlockedAt: 17,
       description: "multiplies Antimatter Dimensions by Reality Machines",
       formatEffect: value => `Multiply Antimatter Dimensions by Reality Machines${formatPow(value, 2, 2)}`,
       reagents: [
@@ -328,8 +312,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => Math.sqrt(amount),
       tier: 4,
       uiOrder: 3,
-      isUnlocked: () => Ra.pets.effarig.level >= 19,
-      lockText: "Effarig Level 19",
+      unlockedAt: 19,
       description: "passively generates Realities and Perk Points",
       formatEffect: value => `Generate ${format(value, 2, 2)} Realities and Perk Points per second`,
       reagents: [
@@ -354,8 +337,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => amount / 80000,
       tier: 4,
       uiOrder: 1,
-      isUnlocked: () => Ra.pets.effarig.level >= 20,
-      lockText: "Effarig Level 20",
+      unlockedAt: 20,
       description: "makes Tesseracts stronger",
       formatEffect: value => `Tesseracts are +${formatPercents(value, 2, 2)} stronger`,
       reagents: [
@@ -376,8 +358,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => 5 * Math.pow(amount / 10000, 2),
       tier: 4,
       uiOrder: 5,
-      isUnlocked: () => Ra.pets.effarig.level >= 16,
-      lockText: "Effarig Level 16",
+      unlockedAt: 16,
       description: "makes each Reality simulate more Realities",
       formatEffect: value => `Each Reality simulates ${format(value, 2, 3)} additional Realities, giving all
         the same rewards as if it was amplified`,
@@ -399,8 +380,7 @@ GameDatabase.celestials.alchemy = {
       effect: amount => amount / (10000 + amount),
       tier: 4,
       uiOrder: 4,
-      isUnlocked: () => Ra.pets.effarig.level >= 21,
-      lockText: "Effarig Level 21",
+      unlockedAt: 21,
       description: "makes each Alchemy Reaction have a chance to happen twice",
       formatEffect: value => `Any alchemy reaction has a ${formatPercents(value, 2, 2)}
         chance of triggering again`,
@@ -427,8 +407,7 @@ GameDatabase.celestials.alchemy = {
       isBaseResource: false,
       effect: amount => Math.floor(amount),
       tier: 5,
-      isUnlocked: () => Ra.pets.effarig.level >= 25,
-      lockText: "Effarig Level 25",
+      unlockedAt: 25,
       description: "allows creation of Reality Glyphs",
       formatEffect: value => `Consume all Reality resource to create a level ${formatInt(value)} Reality Glyph`,
       reagents: [


### PR DESCRIPTION
Change it from `lockText` and `isUnlocked` to `unlockedAt`, which contains just the level the resource unlocks at.
Makes some code in ra-pet-level-bar way easier to read.
Also includes some very small backend changes related to this change.