### PR TITLE
SAM now starts with 2e130

### DIFF
--- a/javascripts/core/secret-formula/reality/perks.js
+++ b/javascripts/core/secret-formula/reality/perks.js
@@ -30,9 +30,9 @@ GameDatabase.reality.perks = {
     label: "SAM",
     family: PERK_FAMILY.ANTIMATTER,
     get description() {
-      return `Start every reset with ${format(1e130)} antimatter.`;
+      return `Start every reset with ${format(2e130)} antimatter.`;
     },
-    bumpCurrency: () => Currency.antimatter.bumpTo(1e130),
+    bumpCurrency: () => Currency.antimatter.bumpTo(2e130),
     effect: 2e130,
     defaultPosition: {
       x: -190,


### PR DESCRIPTION
Apparently tickspeed calculation was changed.
Another problem occured (discord link: https://discord.com/channels/351476683016241162/873641688961257533/877451905029242880)
Idly : "mhm we need to start with 2e130", so here I am

Idlys comment -> https://discord.com/channels/351476683016241162/873641688961257533/877451143628853288