### PR TITLE
Fix offline bugs

### DIFF
--- a/javascripts/game.js
+++ b/javascripts/game.js
@@ -801,6 +801,16 @@ function simulateTime(seconds, real, fast) {
   }
   
   let remainingRealSeconds = seconds;
+  // During async code the number of ticks remaining can go down suddenly
+  // from "Speed up" which means tick length needs to go up, and thus
+  // you can't just divide total time by total ticks to get tick length.
+  // For example, suppose you had 6000 offline ticks, and called "Speed up"
+  // 1000 ticks in, meaning that after "Speed up" there'd only be 1000 ticks more
+  // (so 1000 + 1000 = 2000 ticks total). Dividing total time by total ticks would
+  // use 1/6th of the total time before "Speed up" (1000 of 6000 ticks), and 1/2 after
+  // (1000 of 2000 ticks). Short of some sort of magic user prediction to figure out
+  // whether the user *will* press "Speed up" at some point, dividing remaining time
+  // by remaining ticks seems like the best thing to do.
   let loopFn = i => {
     const diff = remainingRealSeconds / i;
     gameLoop(1000 * diff);
@@ -818,7 +828,13 @@ function simulateTime(seconds, real, fast) {
 
   // We don't show the offline modal here or bother with async if doing a fast simulation
   if (fast) {
+    // Fast simulations happen when simulating between 10 and 50 seconds of offline time.
+    // One easy way to get this is to autosave every 30 or 60 seconds, wait until the save timer
+    // in the bottom-left hits 15 seconds, and refresh (without saving directly beforehand).
     GameIntervals.stop();
+    // Fast simulations are always 50 ticks. They're done in this weird countdown way because
+    // we want to be able to call the same function that we call when using async code (to avoid
+    // duplicating functions), and that function expects a parameter saying how many ticks are remaining.
     for (let remaining = 50; remaining > 0; remaining--) {
       loopFn(remaining);
     }


### PR DESCRIPTION
Fixes #1851 (multiplies diff by 1000)

Fixes NaN bug (passes remaining ticks into game loop when doing "fast" simulateTime (between 10 and 50 seconds of offline progress, we just simulate 50 ticks))