### PR TITLE
Fix the dimboost and galaxy autobuyers triggering in inconsistent ways

### DIFF
--- a/javascripts/core/autobuyers/dimboost-autobuyer.js
+++ b/javascripts/core/autobuyers/dimboost-autobuyer.js
@@ -76,11 +76,14 @@ Autobuyer.dimboost = new class DimBoostAutobuyerState extends UpgradeableAutobuy
   }
 
   get canTick() {
-    return DimBoost.canBeBought && super.canTick;
+    return DimBoost.canBeBought && DimBoost.requirement.isSatisfied && super.canTick;
   }
 
   get resetTickOn() {
-    return Achievement(143).isUnlocked ? PRESTIGE_EVENT.ANTIMATTER_GALAXY : PRESTIGE_EVENT.INFINITY;
+    // Resetting on infinity seems slightly faster than resetting on galaxy before
+    // "Yo dawg, I heard you liked reskins...", and about the same afterwards,
+    // so we always reset on infinity rather than galaxy.
+    return PRESTIGE_EVENT.INFINITY;
   }
 
   tick() {

--- a/javascripts/core/autobuyers/galaxy-autobuyer.js
+++ b/javascripts/core/autobuyers/galaxy-autobuyer.js
@@ -51,12 +51,15 @@ Autobuyer.galaxy = new class GalaxyAutobuyerState extends UpgradeableAutobuyerSt
       : super.interval;
   }
 
+  get canTick() {
+    return Galaxy.canBeBought && Galaxy.requirement.isSatisfied && super.canTick;
+  }
+
   get resetTickOn() {
     return PRESTIGE_EVENT.INFINITY;
   }
 
   tick() {
-    if (!Galaxy.requirement.isSatisfied) return;
     super.tick();
     const limit = this.limitGalaxies ? this.maxGalaxies : Number.MAX_VALUE;
     requestGalaxyReset(this.isBuyMaxUnlocked, limit);


### PR DESCRIPTION
Also change dimboost autobuyer to always reset interval on infinity (previously it reset on galaxy with reskins but after reskins, it didn't matter which it did and before, resetting on infinity was slightly faster for the ~e300 IP save I tried)

<https://discord.com/channels/351476683016241162/700766312556789831/885296408121462874> has helpful context, as does the autobuyers thread linked a few messages below it.