### PR TITLE
De-reactify tachyon particles

### DIFF
--- a/javascripts/components/eternity/dilation/tachyon-particles.js
+++ b/javascripts/components/eternity/dilation/tachyon-particles.js
@@ -45,19 +45,9 @@ Vue.component("tachyon-particle", {
   props: {
     bounds: Object
   },
-  data() {
-    return {
-      x: 0,
-      y: 0
-    };
-  },
   created() {
     this.tween = null;
-    if (GameUI.initialized) {
-      this.fly();
-    } else {
-      Vue.nextTick(() => this.fly());
-    }
+    Vue.nextTick(() => this.fly());
   },
   destroyed() {
     if (this.tween !== null) {
@@ -82,10 +72,14 @@ Vue.component("tachyon-particle", {
       };
       const duration = intersectionLength / speed;
 
-      this.x = start.x;
-      this.y = start.y;
-      this.tween = new TWEEN.Tween(this.$data)
+      const position = start;
+      const el = this.$refs.el;
+      this.tween = new TWEEN.Tween(position)
         .to(intersection, duration)
+        .onUpdate(() => {
+          el.setAttribute("cx", position.x);
+          el.setAttribute("cy", position.y);
+        })
         .easing(TWEEN.Easing.Linear.None)
         .onComplete(this.fly.bind(this))
         .start(tweenTime);
@@ -112,5 +106,5 @@ Vue.component("tachyon-particle", {
     }
   },
   template:
-    `<circle :cx="x" :cy="y" r="2" class="o-tachyon-particle" />`
+    `<circle ref="el" r="2" class="o-tachyon-particle" />`
 });


### PR DESCRIPTION
This PR optimizes tachyon particles by removing the reactive part. Here how it looks like in the profiler (with 6x throttling on my PC):

Before
<img width="635" alt="Screenshot 2021-10-27 214749" src="https://user-images.githubusercontent.com/8434406/139128563-dbdfed20-efa1-41e0-82fc-c582edf5adc9.png">

After
<img width="433" alt="Screenshot 2021-10-27 214852" src="https://user-images.githubusercontent.com/8434406/139128575-85375d00-2d4c-49f1-91ab-5d3fe43e2f2a.png">
