### PR TITLE
Set collapsed back to object if undefined

### DIFF
--- a/javascripts/core/storage/dev-migrations.js
+++ b/javascripts/core/storage/dev-migrations.js
@@ -1265,7 +1265,7 @@ GameStorage.devMigrations = {
     },
     GameStorage.migrations.infMultNameConversion,
     player => {
-      if (typeof player.celestials.pelle.collapsed !== "object") {
+      if (player.celestials.pelle.collapsed === undefined) {
         player.celestials.pelle.collapsed = {
           upgrades: false,
           rifts: false,


### PR DESCRIPTION
This is happening with old saves on master recently. This dev migration should fix the saves where player.celestials.pelle.collapsed got set to undefined