### PR TITLE
Added mozilla bar styling for glyph sac container

### DIFF
--- a/public/stylesheets/glyphs.css
+++ b/public/stylesheets/glyphs.css
@@ -719,17 +719,11 @@
 }
 
 .l-current-glyph-effects::-webkit-scrollbar {
-  width: 1rem;
-}
-
-.l-current-glyph-effects::-webkit-scrollbar-track {
-  box-shadow: inset 0 0 0.5rem grey;
-  border-radius: 1rem;
+  width: 0.8rem;
 }
 
 .l-current-glyph-effects::-webkit-scrollbar-thumb {
   background: #08450b;
-  border-radius: 0.5rem;
 }
 
 .c-current-glyph-effects {


### PR DESCRIPTION
Previously just displayed the normal scrollbar instead of the custom one since webkit doesn't work on moz.

This PR doesn't perfectly emulate the webkit bar styling but it's close enough