### PR TITLE
make pelle require 17 rows of achievements

### DIFF
--- a/javascripts/core/achievements/normal-achievement.js
+++ b/javascripts/core/achievements/normal-achievement.js
@@ -28,6 +28,10 @@ class AchievementState extends GameMechanicState {
     return this.row < 14;
   }
 
+  get isPrePelle() {
+    return this.row < 18;
+  }
+
   get isUnlocked() {
     // eslint-disable-next-line no-bitwise
     return (player.achievementBits[this.row - 1] & this._bitmask) !== 0;
@@ -93,6 +97,13 @@ export const Achievements = {
     return Achievements.all.filter(ach => ach.isPreReality);
   },
 
+  /**
+   * @type {AchievementState[]}
+   */
+  get prePelle() {
+    return Achievements.all.filter(ach => ach.isPrePelle);
+  },
+
   get allRows() {
     const count = Achievements.all.map(a => a.row).max();
     return Achievements.rows(1, count);
@@ -100,6 +111,11 @@ export const Achievements = {
 
   get preRealityRows() {
     const count = Achievements.preReality.map(a => a.row).max();
+    return Achievements.rows(1, count);
+  },
+
+  get prePelleRows() {
+    const count = Achievements.prePelle.map(a => a.row).max();
     return Achievements.rows(1, count);
   },
 

--- a/javascripts/core/secret-formula/reality/imaginary-upgrades.js
+++ b/javascripts/core/secret-formula/reality/imaginary-upgrades.js
@@ -277,7 +277,6 @@ GameDatabase.reality.imaginaryUpgrades = (function() {
       formatEffect: value => `${formatX(value, 2, 1)}`,
     },
     {
-      // TODO Functionality for this needs to be implemented later as Pelle doesn't exist on this branch yet
       name: "Omnipresent Obliteration",
       id: 25,
       cost: 1.6e15,

--- a/src/components/tabs/celestial-pelle/PelleTab.vue
+++ b/src/components/tabs/celestial-pelle/PelleTab.vue
@@ -17,6 +17,8 @@ export default {
   data() {
     return {
       isDoomed: false,
+      canEnterPelle: false,
+      completedRows: 0,
       remnants: 0,
       realityShards: new Decimal(0),
       shardRate: new Decimal(0),
@@ -35,6 +37,10 @@ export default {
   methods: {
     update() {
       this.isDoomed = Pelle.isDoomed;
+      if (!this.isDoomed) {
+        this.canEnterPelle = Achievements.prePelle.every(a => a.isUnlocked);
+        this.completedRows = Achievements.prePelleRows.countWhere(r => r.every(a => a.isUnlocked));
+      }
       this.remnants = Pelle.cel.remnants;
       this.realityShards.copyFrom(Pelle.cel.realityShards);
       this.shardRate.copyFrom(Pelle.realityShardGainPerSecond);
@@ -102,7 +108,7 @@ export default {
       <PelleUpgradePanel :is-hovering="isHovering" />
     </div>
     <button
-      v-else
+      v-else-if="canEnterPelle"
       class="pelle-doom-button"
       @click="enterDoomModal"
     >
@@ -111,6 +117,14 @@ export default {
         <span class="pelle-icon">{{ symbol }}</span>
       </div>
     </button>
+    <div
+      v-else
+      class="pelle-unlock-requirements"
+    >
+      You must have 17 rows of achievements to unlock Doomed.
+      <br>
+      {{ completedRows }} / 17
+    </div>
   </div>
 </template>
 
@@ -154,6 +168,15 @@ export default {
   height: 7rem;
   width: 7rem;
   font-weight: 900;
+}
+
+.pelle-unlock-requirements {
+  font-size: 3rem;
+  background: black;
+  color: var(--color-pelle--base);
+  border: 0.2rem solid var(--color-pelle--base);
+  border-radius: 0.5rem;
+  width: 40rem;
 }
 
 .pelle-doom-button {


### PR DESCRIPTION
also removes an outdated comment


save to test: [PrePelleStartSave.txt](https://github.com/IvarK/IToughtAboutCurseWordsButThatWouldBeMeanToOmsi/files/8251872/PrePelleStartSave.txt)
command to unlock the last achievement: Achievement(178).unlock()