### PR TITLE
Make cost unit in C6 consistent with mobile, and stop it from overflowing

### DIFF
--- a/src/components/tabs/antimatter-dimensions/ClassicAntimatterDimensionRow.vue
+++ b/src/components/tabs/antimatter-dimensions/ClassicAntimatterDimensionRow.vue
@@ -57,7 +57,7 @@ export default {
       return `Purchased ${quantifyInt("time", this.bought)}`;
     },
     costUnit() {
-      return `${AntimatterDimension(this.tier - 2).shortDisplayName} D`;
+      return `${AntimatterDimension(this.tier - 2).shortDisplayName} AD`;
     },
   },
   methods: {

--- a/src/components/tabs/antimatter-dimensions/ModernAntimatterDimensionRow.vue
+++ b/src/components/tabs/antimatter-dimensions/ModernAntimatterDimensionRow.vue
@@ -56,7 +56,7 @@ export default {
       return `Purchased ${quantifyInt("time", this.bought)}`;
     },
     costUnit() {
-      return `${AntimatterDimension(this.tier - 2).shortDisplayName} D`;
+      return `${AntimatterDimension(this.tier - 2).shortDisplayName} AD`;
     },
   },
   methods: {


### PR DESCRIPTION
Resolve #2308

![image](https://user-images.githubusercontent.com/50160441/159127789-53024673-2262-4400-913c-4938c63b5534.png)
