### PR TITLE
Fix Remnant best EP not being reset on 5th strike

### DIFF
--- a/javascripts/core/celestials/pelle/strikes.js
+++ b/javascripts/core/celestials/pelle/strikes.js
@@ -38,7 +38,13 @@ class PelleStrikeState extends GameMechanicState {
     if (this.id === 5) {
       Pelle.cel.records.totalAntimatter = new Decimal("1e180000");
       Pelle.cel.records.totalInfinityPoints = new Decimal("1e60000");
-      Pelle.cel.records.totalEternityPoints = new Decimal("1e400");
+      Currency.eternityPoints.reset();
+      // Oddly specific number? Yes, it's roughly the amount of EP you have
+      // when starting dilation for the first time
+      // Since 5th strike previously did not reset your current EP the previous reset value was kind of useless which
+      // lead to some balancing problems, this hopefully prevents people starting dilation too early and getting
+      // softlocked, or starting it too late and getting not-softlocked.
+      Pelle.cel.records.totalEternityPoints = new Decimal("1e1050");
     }
   }
 


### PR DESCRIPTION
Context: some people didn't even realise that best Pelle EP was reset because dilating didn't reset your current EP, hence not really affecting your best EP much