### PR TITLE
Fix * not being shown at the start of quotes denoting an action in CelQuoteHistory

### DIFF
--- a/src/components/CelestialQuoteHistory.vue
+++ b/src/components/CelestialQuoteHistory.vue
@@ -76,7 +76,7 @@ export default {
       if (this.downButtonEnabled) this.lastVisibleIndex++;
     },
     removeQuoteSyntax(x) {
-      return Modal.celestialQuote.removeOverrideCel(x).replace("*", "");
+      return Modal.celestialQuote.removeOverrideCel(x);
     }
   }
 };


### PR DESCRIPTION
Does exactly what it says. I accidentally removed it while refactoring CelQuoteHistory to .vue a while ago