### PR TITLE
really old saves didnt have laitela.automation so it crashes

### DIFF
--- a/javascripts/core/storage/dev-migrations.js
+++ b/javascripts/core/storage/dev-migrations.js
@@ -1192,7 +1192,7 @@ GameStorage.devMigrations = {
       };
       delete player.options.showCondenseToMilestone;
     },
-    player => {
+    () => {
       // This is just an empty patch because some orders got really messed up. Sorry -Scar
     },
     player => {
@@ -1275,19 +1275,22 @@ GameStorage.devMigrations = {
     },
     player => {
       const from = player.celestials.laitela;
-      player.auto.darkMatterDims.isActive = from.automation.dimensions;
-      player.auto.ascension.isActive = from.automation.ascension;
-      player.auto.annihilation.isActive = from.automation.singularity;
-      player.auto.singularity.isActive = from.automation.annihilation;
+      if (from.automation) {
+        player.auto.darkMatterDims.isActive = from.automation.dimensions;
+        player.auto.ascension.isActive = from.automation.ascension;
+        player.auto.annihilation.isActive = from.automation.singularity;
+        player.auto.singularity.isActive = from.automation.annihilation;
+
+        delete player.celestials.laitela.automation.dimensions;
+        delete player.celestials.laitela.automation.ascension;
+        delete player.celestials.laitela.automation.singularity;
+        delete player.celestials.laitela.automation.annihilation;
+      }
 
       player.auto.darkMatterDims.lastTick = from.darkAutobuyerTimer;
       player.auto.ascension.lastTick = from.darkAutobuyerTimer;
       player.auto.annihilation.multiplier = from.autoAnnihilationSetting;
 
-      delete player.celestials.laitela.automation.dimensions;
-      delete player.celestials.laitela.automation.ascension;
-      delete player.celestials.laitela.automation.singularity;
-      delete player.celestials.laitela.automation.annihilation;
       delete player.celestials.laitela.darkAutobuyerTimer;
       delete player.celestials.laitela.darkAutobuyerTimer;
       delete player.celestials.laitela.autoAnnihilationSetting;


### PR DESCRIPTION
so somewhere along when i was playing, laitela got `.automation` defined - meaning that, since now `laitela.automation` got removed and migrated, the really old saves from my save bank no longer work

also fixes that eslint error with `player` being unused