### PR TITLE
Slightly improve Modify Visible Tabs modal layout

### DIFF
--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -9155,7 +9155,7 @@ input.o-automator-block-input {
 .l-hide-modal-subtab-container {
   display: flex;
   flex-wrap: wrap;
-  width: 70rem;
+  width: 61rem;
   justify-content: center;
   position: relative;
 }

--- a/src/components/modals/options/hidden-tabs/HiddenTabGroup.vue
+++ b/src/components/modals/options/hidden-tabs/HiddenTabGroup.vue
@@ -111,6 +111,7 @@ export default {
   position: absolute;
   right: 0;
   top: 0;
+  width: 2rem;
   padding: 0.2rem;
   text-shadow: none;
 }

--- a/src/components/modals/options/hidden-tabs/HiddenTabsModal.vue
+++ b/src/components/modals/options/hidden-tabs/HiddenTabsModal.vue
@@ -58,6 +58,6 @@ export default {
 
 <style scoped>
 .l-wrapper {
-  width: auto;
+  width: 62rem;
 }
 </style>


### PR DESCRIPTION
- 4 buttons per row for less clutter looking
- Add `width: 2rem;` to indicator icons on right side for better visibility

Before:
![image](https://user-images.githubusercontent.com/56225774/162563451-26fa5f92-4cf7-4f0d-a756-446fc7845862.png)
After:
![image](https://user-images.githubusercontent.com/56225774/162563457-1fdc80b2-bd35-42ec-9248-9d180c1bb011.png)
