### PR TITLE
Make showEPRate and showIPRate consistent with mobile displays

### DIFF
--- a/src/components/ui-modes/HeaderBigCrunchButton.vue
+++ b/src/components/ui-modes/HeaderBigCrunchButton.vue
@@ -25,7 +25,7 @@ export default {
     // Show IP/min below this threshold, color the IP number above it
     rateThreshold: () => 1e100,
     showIPRate() {
-      return this.currentIP.lte(this.rateThreshold);
+      return this.peakIPRate.lte(this.rateThreshold);
     },
     amountStyle() {
       if (!this.headerTextColored || this.currentIP.lt(this.rateThreshold)) return {};
@@ -63,8 +63,8 @@ export default {
       this.gainedIP.copyFrom(gainedIP);
       if (this.showIPRate) {
         this.currentIPRate.copyFrom(gainedIP.dividedBy(Math.clampMin(0.0005, Time.thisInfinityRealTime.totalMinutes)));
-        this.peakIPRate.copyFrom(player.records.thisInfinity.bestIPmin);
       }
+      this.peakIPRate.copyFrom(player.records.thisInfinity.bestIPmin);
     },
     switchToInfinity() {
       Tab.dimensions.infinity.show(true);

--- a/src/components/ui-modes/HeaderEternityButton.vue
+++ b/src/components/ui-modes/HeaderEternityButton.vue
@@ -34,7 +34,7 @@ export default {
     // Show EP/min below this threshold, color the EP number above it
     rateThreshold: () => 1e100,
     showEPRate() {
-      return this.currentEP.lte(this.rateThreshold);
+      return this.peakEPRate.lte(this.rateThreshold);
     },
     isDilation() {
       return this.type === EP_BUTTON_DISPLAY_TYPE.DILATION ||
@@ -136,8 +136,8 @@ export default {
         this.currentEPRate.copyFrom(gainedEP.dividedBy(
           TimeSpan.fromMilliseconds(player.records.thisEternity.realTime).totalMinutes)
         );
-        this.peakEPRate.copyFrom(player.records.thisEternity.bestEPmin);
       }
+      this.peakEPRate.copyFrom(player.records.thisEternity.bestEPmin);
     },
     updateChallengeWithRUPG() {
       const ec = EternityChallenge.current;


### PR DESCRIPTION
ep/ip rate > threshold ==> best ep/ip rate > threshold
Made calculation non-conditional
Resolves #(?????)
![image](https://user-images.githubusercontent.com/50160441/164681940-526eca79-c1ec-4f86-8846-094ebba590c9.png)
