### PR TITLE
fix weird jsconfig errors in vscode

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,11 @@
 {
-    "compilerOptions": {
-      "module": "ES6",
-      "target": "es6"
-    },
-    "include": ["src/**/*", "javascripts/**/*"]
-  }
+  "compilerOptions": {
+    "module": "ES6",
+    "target": "es6"
+  },
+  "include": [
+    "src/**/*",
+    "javascripts/**/*"
+  ],
+  "noEmit": true
+}


### PR DESCRIPTION
was causing some weird vscode errors to appear in some firebase `node_modules` typescript files, which shouldnt happen because its on the default denylist. regardless, this fixes those issues.