### PR TITLE
get 2nd req on ec11 and 12 back if not bought

### DIFF
--- a/javascripts/core/time-studies/ec-time-study.js
+++ b/javascripts/core/time-studies/ec-time-study.js
@@ -117,7 +117,7 @@ export class ECTimeStudyState extends TimeStudyState {
   }
 
   get wasRequirementPreviouslyMet() {
-    if ([11, 12].includes(this.id)) return false;
+    if (this.id === 11 || this.id === 12) return false;
     // eslint-disable-next-line no-bitwise
     return (player.challenge.eternity.requirementBits & (1 << this.id)) !== 0;
   }


### PR DESCRIPTION
Right now the EC11/12 studies are displayed as if they do not have any secondary requirement and could be bought once you bought them and respeced your tree into a different path. However you still need to only purchase AM/TD path in order to enter EC11/12 which doesnt line up with the EC study display.

![image](https://user-images.githubusercontent.com/66326188/165529919-cd985e87-219b-4d27-9df2-2c61281a659c.png)
