### PR TITLE
Lars hide cel quote modal in speedrun

### DIFF
--- a/src/components/modals/CelestialQuoteModal.vue
+++ b/src/components/modals/CelestialQuoteModal.vue
@@ -3,7 +3,6 @@ export default {
   name: "CelestialQuoteModal",
   data() {
     return {
-      noSpeedrun: true,
       index: 0,
       line: "",
       overrideCelestial: "",


### PR DESCRIPTION
this is to hide all celestial quote modals poping up during speedrun

save for testing attached
- use `player.speedrun.isActive=true/false`
- buy dilation study and finish teresas reality

[hide quote modal in speedrun.txt](https://github.com/IvarK/IToughtAboutCurseWordsButThatWouldBeMeanToOmsi/files/8596683/hide.quote.modal.in.speedrun.txt)
