### PR TITLE
Fix H2P info text doesn't cover full modal height

### DIFF
--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -9108,7 +9108,7 @@ input.o-automator-block-input {
 .l-h2p-body {
   flex: 1 1 30rem;
   overflow-y: scroll;
-  margin: 1rem 1rem 0 1rem;
+  margin: 1rem 1rem 0;
   padding: 0.5rem;
 }
 
@@ -9139,7 +9139,7 @@ input.o-automator-block-input {
   justify-content: flex-start;
   flex-direction: column;
   overflow-y: auto;
-  margin: 0.5rem 0.5rem 0 0.5rem;
+  margin: 0.5rem 0.5rem 0;
   flex: 1 0.8 40rem;
   scrollbar-width: thin;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56225774/166255944-27a48238-5ca0-4c6b-914f-c03687fe85d0.png)
