### PR TITLE
Modal priority system updates

### DIFF
--- a/javascripts/core/app/modal.js
+++ b/javascripts/core/app/modal.js
@@ -76,7 +76,7 @@ export class Modal {
     const modalQueue = ui.view.modal.queue;
     // Add this modal to the front of the queue and sort based on priority to ensure priority is maintained.
     modalQueue.unshift(this);
-    modalQueue.sort((x, y) => x.priority < y.priority);
+    modalQueue.sort((x, y) => y.priority - x.priority);
     // Filter out multiple instances of the same modal.
     const singleQueue = [...new Set(modalQueue)];
     ui.view.modal.queue = singleQueue;


### PR DESCRIPTION
- Prioritized modals are no longer forcefully unshifted into the queue, instead shifted to the index before a modal of lower priority is present
- You can now set levels of priority
Modal message and cel quotes are of priority level 2 now, and most confirmation modals are of priority level 1
The rest of the modals are at priority level 0
Fixes a certain checkbox in #2570