### PR TITLE
Fix Glyph info tabs are covering help me buttons

### DIFF
--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -9185,6 +9185,7 @@ input.o-automator-block-input {
   font-size: 1.5rem;
   cursor: pointer;
   font-weight: 500;
+  z-index: 1;
 }
 
 .l-information {


### PR DESCRIPTION
From live:
![image](https://user-images.githubusercontent.com/56225774/167238055-4f7c0206-354f-4f5c-abdc-1d09e249ea5b.png)

From this PR:
![image](https://user-images.githubusercontent.com/56225774/167238060-13b7ec71-c892-4e28-abe8-8d1fbc4cb080.png)
