### PR TITLE
fix teresa tab notification

### DIFF
--- a/javascripts/core/secret-formula/tab-notifications.js
+++ b/javascripts/core/secret-formula/tab-notifications.js
@@ -143,7 +143,7 @@ GameDatabase.tabNotifications = {
         tab: "teresa"
       }
     ],
-    condition: () => player.celestials.teresa.pouredAmount !== 0 && Teresa.isUnlocked,
+    condition: () => player.celestials.teresa.pouredAmount === 0 && Teresa.isUnlocked,
     events: [GAME_EVENT.REALITY_UPGRADE_BOUGHT]
   },
   alchemyUnlock: {


### PR DESCRIPTION
Unlocking cel1 didnt trigger tab notification while unlocking continuum did.

Saves for testing

Save right before buying last rupg & unlocking cel1
[tab notification (pre cel1).txt](https://github.com/IvarK/IToughtAboutCurseWordsButThatWouldBeMeanToOmsi/files/8653175/tab.notification.pre.cel1.txt)

Save right before unlocking cel6 & continuum
[tab notification (pre cel6).txt](https://github.com/IvarK/IToughtAboutCurseWordsButThatWouldBeMeanToOmsi/files/8653174/tab.notification.pre.cel6.txt)

