### PR TITLE
Give an even heavier boost to charged ipgen

### DIFF
--- a/javascripts/core/secret-formula/infinity/infinity-upgrades.js
+++ b/javascripts/core/secret-formula/infinity/infinity-upgrades.js
@@ -176,8 +176,8 @@ GameDatabase.infinity.upgrades = {
     charged: {
       description: () =>
         `Gain Reality Machines each real-time second proportional to amount gained on Reality,
-        proportion increases with Teresa level`,
-      effect: () => Ra.pets.teresa.level * Ra.pets.teresa.level *
+        increasing with Teresa level`,
+      effect: () => Math.pow(Ra.pets.teresa.level, 2) *
         Ra.unlocks.continuousTTBoost.effects.autoPrestige.effectOrDefault(1),
       formatEffect: value => formatX(value, 2, 1)
     }


### PR DESCRIPTION
As multiple people on discord have pointed out, the previous buff was still overall not substantial enough to make a real difference. This should fix some things