### PR TITLE
fix $on typos to on$

### DIFF
--- a/src/components/ExpandingControlBox.vue
+++ b/src/components/ExpandingControlBox.vue
@@ -104,7 +104,7 @@ export default {
   },
   created() {
     this.state = this.states.CLOSED;
-    this.$on("openrequest", () => this.openRequest = true);
+    this.on$("openrequest", () => this.openRequest = true);
   },
   mounted() {
     // Set the root and container elements to match the height of the button

--- a/src/components/GlyphComponent.vue
+++ b/src/components/GlyphComponent.vue
@@ -255,7 +255,7 @@ export default {
     }
   },
   created() {
-    this.$on("tooltip-touched", () => this.hideTooltip());
+    this.on$("tooltip-touched", () => this.hideTooltip());
   },
   beforeDestroy() {
     if (this.isCurrentTooltip) this.hideTooltip();

--- a/src/components/modals/prestige/BigCrunchModal.vue
+++ b/src/components/modals/prestige/BigCrunchModal.vue
@@ -20,9 +20,9 @@ export default {
     },
   },
   created() {
-    this.$on(GAME_EVENT.INFINITY_RESET_AFTER, this.emitClose);
-    this.$on(GAME_EVENT.ETERNITY_RESET_AFTER, this.emitClose);
-    this.$on(GAME_EVENT.REALITY_RESET_AFTER, this.emitClose);
+    this.on$(GAME_EVENT.INFINITY_RESET_AFTER, this.emitClose);
+    this.on$(GAME_EVENT.ETERNITY_RESET_AFTER, this.emitClose);
+    this.on$(GAME_EVENT.REALITY_RESET_AFTER, this.emitClose);
   },
   methods: {
     update() {


### PR DESCRIPTION
was just a typo at some long indeterminate past. we use `on$`. this fixes a few bugs, including the big crunch modal not closing when it should