### PR TITLE
Fix reactivity issues on switching modes

### DIFF
--- a/src/components/modals/ModalWrapperChoice.vue
+++ b/src/components/modals/ModalWrapperChoice.vue
@@ -35,11 +35,6 @@ export default {
       type: String,
       required: false,
       default: undefined
-    },
-    closeOnConfirm: {
-      type: Boolean,
-      required: false,
-      default: true
     }
   },
   created() {
@@ -48,7 +43,7 @@ export default {
   methods: {
     doConfirm() {
       this.$emit("confirm");
-      if (this.closeOnConfirm) EventHub.dispatch(GAME_EVENT.CLOSE_MODAL);
+      EventHub.dispatch(GAME_EVENT.CLOSE_MODAL);
     },
     doCancel() {
       this.$emit("cancel");

--- a/src/components/modals/SwitchAutomatorEditorModal.vue
+++ b/src/components/modals/SwitchAutomatorEditorModal.vue
@@ -35,7 +35,6 @@ export default {
     toggleAutomatorMode() {
       const scriptID = this.currentScriptID;
       Tutorial.moveOn(TUTORIAL_STATE.AUTOMATOR);
-      this.emitClose();
       if (this.isCurrentlyBlocks) {
         // This saves the script after converting it.
         BlockAutomator.parseTextFromBlocks();
@@ -55,7 +54,6 @@ export default {
 <template>
   <ModalWrapperChoice
     option="switchAutomatorMode"
-    :close-on-confirm="false"
     @confirm="toggleAutomatorMode"
   >
     <template #header>

--- a/src/components/tabs/automator/AutomatorControls.vue
+++ b/src/components/tabs/automator/AutomatorControls.vue
@@ -73,7 +73,12 @@ export default {
     },
     rewind: () => AutomatorBackend.restart(),
     play() {
-      if (this.hasErrors) return;
+      if (this.hasErrors) {
+        // This shouldn't be needed but someone's save was still on MODE.RUN when the script had errors so this
+        // is just an additional layer of failsafe in case something goes wrong
+        AutomatorBackend.mode = AUTOMATOR_MODE.PAUSED;
+        return;
+      }
       if (this.isRunning) {
         AutomatorBackend.pause();
         return;

--- a/src/components/tabs/automator/AutomatorModeSwitch.vue
+++ b/src/components/tabs/automator/AutomatorModeSwitch.vue
@@ -62,7 +62,7 @@ export default {
       this.$nextTick(() => BlockAutomator.fromText(this.currentScript));
     },
     toggleAutomatorMode() {
-      if (AutomatorBackend.state.mode === AUTOMATOR_MODE.PAUSE || !player.options.confirmations.switchAutomatorMode) {
+      if (AutomatorBackend.mode !== AUTOMATOR_MODE.RUN || !player.options.confirmations.switchAutomatorMode) {
         const scriptID = this.currentScriptID;
         Tutorial.moveOn(TUTORIAL_STATE.AUTOMATOR);
         if (this.automatorType === AUTOMATOR_TYPE.BLOCK) {


### PR DESCRIPTION
Sometimes switch mode will show there is an error in textmato and it can't be switched to textmato after fixing all errors.
(And also fix cases where the confirm switch modes modal wouldn't close if the script had errors)