### PR TITLE
Make s10 not have box shadows on tab btns in classic 

### DIFF
--- a/public/stylesheets/old-ui.css
+++ b/public/stylesheets/old-ui.css
@@ -76,6 +76,10 @@
   box-shadow: none;
 }
 
+.t-s10 .o-tab-btn {
+  box-shadow: none;
+}
+
 .o-tab-btn--secondary {
   width: 17.5rem;
   height: 2.5rem;


### PR DESCRIPTION
Resolve #2715 