### PR TITLE
do not generate new ID for existing glyphs, fixes #2290

### DIFF
--- a/javascripts/core/glyphs/glyph-core.js
+++ b/javascripts/core/glyphs/glyph-core.js
@@ -326,7 +326,7 @@ export const Glyphs = {
   },
   addToInventory(glyph, requestedInventoryIndex, isExistingGlyph = false) {
     this.validate();
-    glyph.id = GlyphGenerator.makeID();
+    if (!isExistingGlyph) glyph.id = GlyphGenerator.makeID();
     const isProtectedIndex = requestedInventoryIndex < this.protectedSlots;
     let index = this.findFreeIndex(isProtectedIndex);
     if (index < 0) return;


### PR DESCRIPTION
So while investigating #2290 I realized that we generate new IDs to existing glyphs when they are unequipped. Changing that seemingly fixed the issue, I really don't know why though.