### PR TITLE
Fix error caused from just typing into console

### DIFF
--- a/javascripts/core/crash.js
+++ b/javascripts/core/crash.js
@@ -42,4 +42,7 @@ window.GlobalErrorHandler = {
   }
 };
 
-window.onerror = event => GlobalErrorHandler.onerror(event);
+window.onerror = (event, source) => {
+  if (!source.endsWith(".js")) return;
+  GlobalErrorHandler.onerror(event);
+};


### PR DESCRIPTION
So I had this weird issue happening where the game just crashed every time I wrote anything to the console (I didn't even have to press enter).

So I googled and found this https://stackoverflow.com/questions/72396527/evalerror-possible-side-effect-in-debug-evaluate-in-google-chrome

Seems to fix the issue, although I couldn't get the onerror to trigger from throwing errors in the code, so I'm unsure what triggers it.