### PR TITLE
Fix import from file console error

### DIFF
--- a/src/components/tabs/options-saving/OptionsSavingTab.vue
+++ b/src/components/tabs/options-saving/OptionsSavingTab.vue
@@ -40,6 +40,8 @@ export default {
       this.userName = Cloud.user.displayName;
     },
     importAsFile(event) {
+      // This happens if the file dialog is canceled instead of a file being selected
+      if (event.target.files.length === 0) return;
       const reader = new FileReader();
       reader.onload = function() {
         GameStorage.import(reader.result);


### PR DESCRIPTION
Fixes a bug found in #2708 but turns out already existed on master. Most reliable repro steps seem to be to import a save from a file, and then quickly attempt to do that again but cancel out of the file dialog instead of selecting one. I could only repro it maybe 50% of the time when testing on master and couldn't repro it at all after making this change, so an additional look by anyone who can repro it more reliably on master would be appreciated.

Incidentally, and fun fact, the `Blob` is part of the error message and not due to anything we've done :blob: