### PR TITLE
Fix slider behaviour when dragging on right side

### DIFF
--- a/src/components/SliderComponent.vue
+++ b/src/components/SliderComponent.vue
@@ -1030,7 +1030,10 @@ export default {
          :class="['l-ad-slider__wrap', stateClass]"
          :style="[wrapStyles, boolDisabled ? disabledStyle : null]"
          @click="wrapClick">
-      <div ref="elem" aria-hidden="true" :class="['l-ad-slider__bg', 'c-ad-slider__bg', bgClass]" :style="[elemStyles, bgStyle]">
+      <div ref="elem" aria-hidden="true" :class="['l-ad-slider__bg', 'c-ad-slider__bg', bgClass]" :style="[elemStyles, bgStyle]"
+        @mousedown="moveStart($event, 0, true)"
+        @touchstart="moveStart($event, 0, true)"
+      >
         <template v-if="isRange">
           <div
             ref="dot0"
@@ -1043,8 +1046,8 @@ export default {
             }
           ]"
             :style="dotStyles"
-            @mousedown="moveStart($event, 0)"
-            @touchstart="moveStart($event, 0)"
+            @mousedown="moveStart"
+            @touchstart="moveStart"
           >
             <div
               :class="['l-ad-slider__dot-handle', 'c-ad-slider__dot-handle', dotClass]"
@@ -1139,8 +1142,6 @@ export default {
           :class="['l-ad-slider__process', 'c-ad-slider__process', { 'ad-slider-process-draggable': isRange && processDraggable }, processClass]"
           :style="processStyle"
           @click="processClick"
-          @mousedown="moveStart($event, 0, true)"
-          @touchstart="moveStart($event, 0, true)"
         >
           <div
             ref="mergedTooltip"


### PR DESCRIPTION
When dragging on the right side of the knob of slider-component, the slider head does not move along the knob. This behaviour is not true for the left side, where dragging does move along the knob.