### PR TITLE
check if dev migration rifts exists before referencing it

### DIFF
--- a/javascripts/core/storage/dev-migrations.js
+++ b/javascripts/core/storage/dev-migrations.js
@@ -1370,29 +1370,37 @@ GameStorage.devMigrations = {
       delete player.celestials.pelle.quotes;
     },
     player => {
-      player.celestials.pelle.rifts.vacuum = {
-        ...player.celestials.pelle.rifts.famine,
-        fill: new Decimal(player.celestials.pelle.rifts.famine.fill)
-      };
-      delete player.celestials.pelle.rifts.famine;
+      if (player.celestials.pelle.rifts.famine) {
+        player.celestials.pelle.rifts.vacuum = {
+          ...player.celestials.pelle.rifts.famine,
+          fill: new Decimal(player.celestials.pelle.rifts.famine.fill)
+        };
+        delete player.celestials.pelle.rifts.famine;
+      }
 
-      player.celestials.pelle.rifts.decay = {
-        ...player.celestials.pelle.rifts.pestilence,
-        fill: new Decimal(player.celestials.pelle.rifts.pestilence.fill)
-      };
-      delete player.celestials.pelle.rifts.pestilence;
+      if (player.celestials.pelle.rifts.pestilence) {
+        player.celestials.pelle.rifts.decay = {
+          ...player.celestials.pelle.rifts.pestilence,
+          fill: new Decimal(player.celestials.pelle.rifts.pestilence.fill)
+        };
+        delete player.celestials.pelle.rifts.pestilence;
+      }
 
-      player.celestials.pelle.rifts.recursion = {
-        ...player.celestials.pelle.rifts.war,
-        fill: new Decimal(player.celestials.pelle.rifts.war.fill)
-      };
-      delete player.celestials.pelle.rifts.war;
+      if (player.celestials.pelle.rifts.war) {
+        player.celestials.pelle.rifts.recursion = {
+          ...player.celestials.pelle.rifts.war,
+          fill: new Decimal(player.celestials.pelle.rifts.war.fill)
+        };
+        delete player.celestials.pelle.rifts.war;
+      }
 
-      player.celestials.pelle.rifts.paradox = {
-        ...player.celestials.pelle.rifts.death,
-        fill: new Decimal(player.celestials.pelle.rifts.death.fill)
-      };
-      delete player.celestials.pelle.rifts.death;
+      if (player.celestials.pelle.rifts.death) {
+        player.celestials.pelle.rifts.paradox = {
+          ...player.celestials.pelle.rifts.death,
+          fill: new Decimal(player.celestials.pelle.rifts.death.fill)
+        };
+        delete player.celestials.pelle.rifts.death;
+      }
     },
     player => {
       delete player.newGame;


### PR DESCRIPTION
on old saves, these are undefined, and so cause errors. this checks if they exist before using them