### PR TITLE
Add margin in offline progress simulation modal

### DIFF
--- a/src/components/modals/ModalProgressBar.vue
+++ b/src/components/modals/ModalProgressBar.vue
@@ -121,6 +121,6 @@ export default {
 }
 
 .modal-progress-bar__margin {
-  margin: 2rem 0;
+  margin: 1rem 0;
 }
 </style>


### PR DESCRIPTION
because it looks bad in Firefox.

Live, Chrome vs Firefox
![image](https://user-images.githubusercontent.com/56225774/177330389-0fc7c53e-800d-4518-8eed-3b201451c17c.png)

PR, Chrome vs Firefox
![image](https://user-images.githubusercontent.com/56225774/177330410-4df58b45-df6d-4e24-8c3f-04d7108d3639.png)
