### PR TITLE
Limit study string to 1500 chars

### DIFF
--- a/src/components/modals/StudyStringModal.vue
+++ b/src/components/modals/StudyStringModal.vue
@@ -172,6 +172,7 @@ export default {
       ref="input"
       v-model="input"
       type="text"
+      maxlength="1500"
       class="c-modal-input c-modal-import-tree__input"
       @keyup.enter="confirm"
       @keyup.esc="emitClose"


### PR DESCRIPTION
Resolve #2831

Realistically nobody would need this many, this is just to make sure save files are safe