### PR TITLE
fix eternity button missing its shadow

### DIFF
--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -1903,6 +1903,10 @@ br {
   border-color: black;
 }
 
+.s-base--metro .o-eternity-button {
+  box-shadow: 0.1rem 0.1rem 0.1rem 0 #9e9e9e;
+}
+
 .o-eternity-button--dilation {
   font-weight: bold;
   color: var(--color-dilation);


### PR DESCRIPTION
its on the infinity button, should be on here. its not particularly noticible with the black button, but it was *very* noticible when i looked at #2842. 

before:
![Screenshot_21](https://user-images.githubusercontent.com/25394029/180196279-eaab6b47-f4e0-4522-8e0c-a782ba03d756.png)
now:
![Screenshot_21-2](https://user-images.githubusercontent.com/25394029/180196441-aab4f702-5586-445f-8e8f-171ec8464fca.png)

