### PR TITLE
Make glyph weights always integer

### DIFF
--- a/javascripts/core/glyphs/auto-glyph-processor.js
+++ b/javascripts/core/glyphs/auto-glyph-processor.js
@@ -131,10 +131,27 @@ export function autoAdjustGlyphWeights() {
   const sources = getGlyphLevelSources();
   const f = x => Math.pow(Math.clampMin(1, Math.log(5 * x)), 3 / 2);
   const totalWeight = Object.values(sources).map(s => f(s.value)).sum();
-  player.celestials.effarig.glyphWeights.ep = 100 * f(sources.ep.value) / totalWeight;
-  player.celestials.effarig.glyphWeights.repl = 100 * f(sources.repl.value) / totalWeight;
-  player.celestials.effarig.glyphWeights.dt = 100 * f(sources.dt.value) / totalWeight;
-  player.celestials.effarig.glyphWeights.eternities = 100 * f(sources.eternities.value) / totalWeight;
+  const scaledWeight = key => 100 * f(sources[key].value) / totalWeight;
+
+  // Adjust all weights to be integer, while maintaining that they must sum to 100. We ensure it's within 1 on the
+  // weights by flooring and then taking guesses on which ones would give the largest boost when adding the lost
+  // amounts. This isn't necessarily the best integer weighting, but gives a result that's quite literally within
+  // 99.97% of the non-integer optimal settings and prevents the total from exceeding 100.
+  const weightKeys = ["ep", "repl", "dt", "eternities"];
+  const weights = [];
+  for (const key of weightKeys) {
+    weights.push({
+      key,
+      percent: scaledWeight(key)
+    });
+  }
+  const fracPart = x => x - Math.floor(x);
+  const priority = weights.sort((a, b) => fracPart(b.percent) - fracPart(a.percent)).map(w => w.key);
+  const missingPercent = 100 - weights.map(w => Math.floor(w.percent)).reduce((a, b) => a + b);
+  for (let i = 0; i < weightKeys.length; i++) {
+    const key = priority[i];
+    player.celestials.effarig.glyphWeights[key] = Math.floor(scaledWeight(key)) + (i < missingPercent ? 1 : 0);
+  }
 }
 
 function getGlyphLevelSources() {


### PR DESCRIPTION
Since the player is only capable of integer adjustments, this also changes auto-adjustment to be constrained to integers as well. This is probably a cleaner solution than changing all the weights upon manual adjustment due to the number of edge cases that would need to consider.

Strictly speaking, this change is a very tiny nerf to auto-adjustment. Compared to current master, this results in about 5 less glyph levels at endgame (where it would have the largest effect), which is less than 0.05% of a difference.