### PR TITLE
Fix destabilization being significantly slower than intended

### DIFF
--- a/javascripts/core/dimensions/antimatter-dimension.js
+++ b/javascripts/core/dimensions/antimatter-dimension.js
@@ -54,7 +54,6 @@ export function antimatterDimensionCommonMultiplier() {
 
 export function getDimensionFinalMultiplierUncached(tier) {
   if (tier < 1 || tier > 8) throw new Error(`Invalid Antimatter Dimension tier ${tier}`);
-  if (Laitela.isRunning && tier > Laitela.maxAllowedDimension) return DC.D0;
   if (NormalChallenge(10).isRunning && tier > 6) return DC.D1;
   if (EternityChallenge(11).isRunning) {
     return Currency.infinityPower.value.pow(
@@ -564,6 +563,7 @@ class AntimatterDimensionState extends DimensionState {
 
   get productionPerSecond() {
     const tier = this.tier;
+    if (Laitela.isRunning && tier > Laitela.maxAllowedDimension) return DC.D0;
     let amount = this.totalAmount;
     if (NormalChallenge(12).isRunning) {
       if (tier === 2) amount = amount.pow(1.6);

--- a/javascripts/core/dimensions/infinity-dimension.js
+++ b/javascripts/core/dimensions/infinity-dimension.js
@@ -125,6 +125,10 @@ class InfinityDimensionState extends DimensionState {
   }
 
   get productionPerSecond() {
+    if (EternityChallenge(2).isRunning || EternityChallenge(10).isRunning ||
+      (Laitela.isRunning && this.tier > Laitela.maxAllowedDimension)) {
+      return DC.D0;
+    }
     let production = this.amount;
     if (EternityChallenge(11).isRunning) {
       return production;
@@ -137,11 +141,6 @@ class InfinityDimensionState extends DimensionState {
 
   get multiplier() {
     const tier = this.tier;
-
-    if (EternityChallenge(2).isRunning || EternityChallenge(10).isRunning ||
-      (Laitela.isRunning && this.tier > Laitela.maxAllowedDimension)) {
-      return DC.D0;
-    }
     if (EternityChallenge(11).isRunning) return DC.D1;
     let mult = GameCache.infinityDimensionCommonMultiplier.value
       .timesEffectsOf(

--- a/javascripts/core/dimensions/time-dimension.js
+++ b/javascripts/core/dimensions/time-dimension.js
@@ -182,11 +182,6 @@ class TimeDimensionState extends DimensionState {
   get multiplier() {
     const tier = this._tier;
 
-    if (EternityChallenge(1).isRunning || EternityChallenge(10).isRunning ||
-      (Laitela.isRunning && tier > Laitela.maxAllowedDimension)) {
-      return DC.D0;
-    }
-
     if (EternityChallenge(11).isRunning) return DC.D1;
     let mult = GameCache.timeDimensionCommonMultiplier.value
       .timesEffectsOf(
@@ -221,6 +216,10 @@ class TimeDimensionState extends DimensionState {
   }
 
   get productionPerSecond() {
+    if (EternityChallenge(1).isRunning || EternityChallenge(10).isRunning ||
+    (Laitela.isRunning && this.tier > Laitela.maxAllowedDimension)) {
+      return DC.D0;
+    }
     if (EternityChallenge(11).isRunning) {
       return this.amount;
     }


### PR DESCRIPTION
This one is going to take a bit of explanation, but the short answer is that it came from having a relatively in-depth conversation with some people re-testing cel6 about mechanics and pacing. We came to the conclusion that something was very wrong with cel6 pacing compared to how it was initially set out in #1682, considering that I was the one who originally re-paced it. We largely found this out through some lengthy open discussion of exactly how long everything was taking, with concrete times to various content milestones, and realized that none of the times were what they should've been.

Upon closer examination and careful local branch reverts, I found [the guilty commit](https://github.com/IvarK/IToughtAboutCurseWordsButThatWouldBeMeanToOmsi/pull/1682/commits/4a19847d493bd2307eece1c5834434b5c42b07e5) which was causing the discrepancy. The nerf stems from changing the Lai'tela dimension disabling effect from "zeroing out production" to "zeroing out multipliers" because this disables the IC8 reward (and many sacrifice-related effects) entirely after the first destabilization. At this stage of the game, IC8 alone removes about a total e3e9 multiplier to antimatter gain.

There may be other things it disables, but at this point the simpler solution seems to be to revert that instead of trying to track down any additional side-effects it caused. Based on some saves being passed around and my old bank of iM testing saves, destabilization times are about twice as long as they should be because of this nerf.

tl;dr: a seemingly innocuous change between the most recent re-pacing of cel6 and its actual merge into the main testing branch resulted in a massive unintended nerf, and this branch reverts that change. My apologies to all of wave 3 who had to go through cel6 being way slower than intended.