### PR TITLE
Cursor on Glyph set preview in set deletion modal

### DIFF
--- a/src/components/GlyphSetPreview.vue
+++ b/src/components/GlyphSetPreview.vue
@@ -101,7 +101,7 @@ export default {
     </span>
     <span
       v-if="glyphs.length !== 0"
-      class="l-glyph-set-preview"
+      :class="{ 'l-glyph-set-preview': !isInModal}"
       @click="showModal"
     >
       <GlyphSetName


### PR DESCRIPTION
shouldn't be zoom-in, because it is not clickable.

![image](https://user-images.githubusercontent.com/56225774/182005631-8b789a8f-02a3-4d11-a7cb-5211f6f5e93e.png)
