### PR TITLE
Wider mato panel

### DIFF
--- a/public/stylesheets/automator.css
+++ b/public/stylesheets/automator.css
@@ -36,7 +36,8 @@
 }
 
 .c-automator-tab {
-  width: 100rem;
+  width: 80%;
+  min-width: 100rem;
 }
 
 .c-automator-split-pane {


### PR DESCRIPTION
I made mato panel wider when the window width is wider.
I did it because I felt the mato panel width is unnecessarily too nallow.
I can do even wider (like 95%), but I thought 80% is comfortable.