### PR TITLE
Align pulsing icons in center

### DIFF
--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -2330,7 +2330,8 @@ br {
 }
 
 .u-fa-padding {
-  width: 1rem;
+  width: 1.2rem;
+  align-content: center;
 }
 
 /* #endregion Header */


### PR DESCRIPTION
Pulsing icons are left aligned, and it looks a bit odd, because width of icons are slightly different. This PR fixes it by aligning them on center.

![image](https://user-images.githubusercontent.com/56225774/184271168-538e2e84-c7f2-4ab7-a58d-2cc28d319584.png)
