### PR TITLE
Normal cursor for non-clickable autobuyer upgrades

### DIFF
--- a/src/components/tabs/autobuyers/AutobuyerIntervalButton.vue
+++ b/src/components/tabs/autobuyers/AutobuyerIntervalButton.vue
@@ -11,14 +11,25 @@ export default {
     return {
       cost: 0,
       isMaxed: false,
-      isUnlocked: false
+      isUnlocked: false,
+      isAffordable: false
     };
+  },
+  computed: {
+    classObject() {
+      return {
+        "o-autobuyer-btn": true,
+        "l-autobuyer-box__button": true,
+        "o-non-clickable": !this.isAffordable
+      };
+    }
   },
   methods: {
     update() {
       this.cost = this.autobuyer.cost;
       this.isMaxed = this.autobuyer.hasMaxedInterval;
       this.isUnlocked = this.autobuyer.isUnlocked;
+      this.isAffordable = Currency.infinityPoints.gte(this.cost);
     },
     upgradeInterval() {
       this.autobuyer.upgradeInterval();
@@ -30,7 +41,7 @@ export default {
 <template>
   <button
     v-if="!isMaxed && isUnlocked"
-    class="o-autobuyer-btn l-autobuyer-box__button"
+    :class="classObject"
     @click="upgradeInterval"
   >
     {{ formatPercents(0.4) }} smaller interval
@@ -39,12 +50,14 @@ export default {
   </button>
   <button
     v-else-if="!isMaxed"
-    class="o-autobuyer-btn l-autobuyer-box__button"
+    class="o-autobuyer-btn l-autobuyer-box__button o-non-clickable"
   >
     Complete the challenge to upgrade interval
   </button>
 </template>
 
 <style scoped>
-
+.o-non-clickable {
+  cursor: auto;
+}
 </style>

--- a/src/components/tabs/autobuyers/DimensionBulkButton.vue
+++ b/src/components/tabs/autobuyers/DimensionBulkButton.vue
@@ -14,7 +14,8 @@ export default {
       isUnlocked: false,
       bulkUnlimited: false,
       bulk: 1,
-      cost: 1
+      cost: 1,
+      isAffordable: false
     };
   },
   computed: {
@@ -24,6 +25,12 @@ export default {
       }
       const newBulk = Math.min(this.bulk * 2, this.autobuyer.bulkCap);
       return `${formatX(this.bulk, 2, 0)} ➜ ${formatX(newBulk, 2, 0)} bulk buy`;
+    },
+    classObject() {
+      return {
+        "o-autobuyer-btn": true,
+        "o-non-clickable": !this.isAffordable || this.hasMaxedBulk
+      };
     }
   },
   methods: {
@@ -35,6 +42,7 @@ export default {
       this.bulkUnlimited = autobuyer.hasUnlimitedBulk;
       this.bulk = autobuyer.bulk;
       this.cost = autobuyer.cost;
+      this.isAffordable = Currency.infinityPoints.gte(this.cost);
     },
     upgradeBulk() {
       this.autobuyer.upgradeBulk();
@@ -46,7 +54,7 @@ export default {
 <template>
   <button
     v-if="hasMaxedInterval && !bulkUnlimited && isUnlocked"
-    class="o-autobuyer-btn"
+    :class="classObject"
     @click="upgradeBulk"
   >
     <span>{{ bulkDisplay }}</span>
@@ -57,12 +65,14 @@ export default {
   </button>
   <button
     v-else-if="hasMaxedInterval && !bulkUnlimited"
-    class="o-autobuyer-btn l-autobuyer-box__button"
+    class="o-autobuyer-btn l-autobuyer-box__button o-non-clickable"
   >
     Complete the challenge to upgrade bulk
   </button>
 </template>
 
 <style scoped>
-
+.o-non-clickable {
+  cursor: auto;
+}
 </style>

--- a/src/components/tabs/autobuyers/TickspeedAutobuyerBox.vue
+++ b/src/components/tabs/autobuyers/TickspeedAutobuyerBox.vue
@@ -56,7 +56,7 @@ export default {
       </button>
       <button
         v-else
-        class="o-autobuyer-btn"
+        class="o-autobuyer-btn o-non-clickable"
       >
         Complete the challenge to change mode
       </button>
@@ -65,5 +65,7 @@ export default {
 </template>
 
 <style scoped>
-
+.o-non-clickable {
+  cursor: auto;
+}
 </style>


### PR DESCRIPTION
Do not apply pointer cursor for autobuyer upgrades if;
- challenge completion is needed
- currency is not enough
- fully upgraded already