### PR TITLE
Fix replicanti calculation

### DIFF
--- a/javascripts/core/replicanti.js
+++ b/javascripts/core/replicanti.js
@@ -157,17 +157,20 @@ export function replicantiLoop(diff) {
   tickCount = tickCount.floor();
 
   const singleTickAvg = Replicanti.amount.times(player.replicanti.chance);
+  // Note that code inside this conditional won't necessarily run every game tick; when game ticks are slower than
+  // replicanti ticks, then tickCount will look like [0, 0, 0, 1, 0, 0, ...] on successive game ticks
   if (tickCount.gte(100) || (singleTickAvg.gte(10) && tickCount.gte(1))) {
     // Fast gain: If we're doing a very large number of ticks or each tick produces a lot, then continuous growth
-    // is a good approximation and less intensive than distribution samples. This path will always happen above 1000
-    // replicanti due to how singleTickAvg is calculated, so the over-cap math is only present on this path
+    // every replicanti tick is a good approximation and less intensive than distribution samples. This path will
+    // always happen above 1000 replicanti due to how singleTickAvg is calculated, so the over-cap math is only
+    // present on this path
     let postScale = Math.log10(ReplicantiGrowth.scaleFactor) / ReplicantiGrowth.scaleLog10;
     if (V.isRunning) {
       postScale *= 2;
     }
 
     // Note that remainingGain is in log10 terms.
-    let remainingGain = Decimal.divide(diff * Math.log(player.replicanti.chance + 1), interval).times(LOG10_E);
+    let remainingGain = tickCount.times(Math.log(player.replicanti.chance + 1)).times(LOG10_E);
     // It is intended to be possible for both of the below conditionals to trigger.
     if (!isUncapped || Replicanti.amount.lte(replicantiCap())) {
       // Some of the gain is "used up" below e308, but if replicanti are uncapped


### PR DESCRIPTION
This is a fix for replicanti being produced much more slowly than intended when the game tick is shorter than the replicanti interval.

Technical details:
- At one point of the replicanti loop, we calculate the gain factor as (1+chance)^(diff/interval)
- This is mathematically correct in theory, but in practice that part of the code was only ever reached whenever the internal replicanti timer counts to a full tick and was otherwise completely ignored
- Due to diff/interval being based on the current tick time, this resulted in production that effectively depended on the ratio of game-tick to replicanti-tick _squared_ because the fact that ticks are slow was being effectively applied twice
- The fix is to replace diff/interval (always fractional, can be less than 1) with the tick count (can be zero, equals diff/interval on average) so that every time a replicanti tick is applied, the full tick of production occurs

As a concrete example of how this was going wrong:
- Suppose game tick is 50ms and replicanti tick is 200ms
- The game _should_ have applied [0, 0, 0, 1, 0, 0, 0, 1, ...] ticks of production but was incorrectly applying [0, 0, 0, 0.25, 0, 0, 0, 0.25, ...] ticks instead (on master)
- This change applies that fix and seems to be accurate in-game.

This _might_ introduce some odd edge case behavior for when replicanti is uncapped but the _base_ replicanti interval is still slow. Dan and I are still investigating that, and will post any follow-up information we find.