### PR TITLE
Hide dynamic amount when not on amount mode

### DIFF
--- a/src/components/tabs/autobuyers/BigCrunchAutobuyerBox.vue
+++ b/src/components/tabs/autobuyers/BigCrunchAutobuyerBox.vue
@@ -30,7 +30,8 @@ export default {
       AUTO_CRUNCH_MODE.AMOUNT,
       AUTO_CRUNCH_MODE.TIME,
       AUTO_CRUNCH_MODE.X_HIGHEST,
-    ]
+    ],
+    amountMode: () => AUTO_ETERNITY_MODE.AMOUNT
   },
   watch: {
     increaseWithMult(newValue) {
@@ -129,7 +130,7 @@ export default {
       />
     </template>
     <template
-      v-if="postBreak && mode === 0"
+      v-if="postBreak && mode === amountMode"
       #checkboxSlot
     >
       <label

--- a/src/components/tabs/autobuyers/EternityAutobuyerBox.vue
+++ b/src/components/tabs/autobuyers/EternityAutobuyerBox.vue
@@ -26,7 +26,8 @@ export default {
       AUTO_ETERNITY_MODE.AMOUNT,
       AUTO_ETERNITY_MODE.TIME,
       AUTO_ETERNITY_MODE.X_HIGHEST,
-    ]
+    ],
+    amountMode: () => AUTO_ETERNITY_MODE.AMOUNT
   },
   watch: {
     increaseWithMult(newValue) {
@@ -108,7 +109,7 @@ export default {
       />
     </template>
     <template
-      v-if="mode === 0"
+      v-if="mode === amountMode"
       #checkboxSlot
     >
       <label


### PR DESCRIPTION
This is an interesting way of doing this that can be improved by doing something like adding `showDynamic` to `modeProps` but this also gets the job done and can be changed easily. 

Fixes #2945 