### PR TITLE
Fix unclickable back to docs list on mato

### DIFF
--- a/public/stylesheets/automator.css
+++ b/public/stylesheets/automator.css
@@ -272,6 +272,8 @@
 
 .c-automator-docs {
   overflow: auto;
+  position: relative;
+  z-index: 1;
   text-align: left;
   font-size: 1.4rem;
   color: var(--color-automator-docs-font);
@@ -311,9 +313,8 @@
 }
 
 .c-automator-docs-script-select {
-  height: calc(2.1rem + 1rem / 3 - var(--var-border-width, 0rem) * 2);
   width: 100%;
-  padding: 0.1rem 0.5rem 0;
+  height: calc(2.1rem + 1rem / 3 - var(--var-border-width, 0rem) * 2);
   text-align: left;
   font-family: Typewriter, serif;
   font-size: 1.2rem;
@@ -321,6 +322,7 @@
   background-color: var(--color-automator-controls-inactive);
   border: var(--var-border-width, 0.2rem) solid var(--color-automator-controls-border);
   border-radius: var(--var-border-radius, 0.3rem);
+  padding: 0.1rem 0.5rem 0;
   cursor: pointer;
 }
 


### PR DESCRIPTION
Resolve #2975 

Turns out that the people who made codemirror made a magic number fix to get their scrollbars to work. How convenient.