### PR TITLE
Stop respec secret achievement from being given so much, fixes #2998

### DIFF
--- a/javascripts/core/eternity.js
+++ b/javascripts/core/eternity.js
@@ -70,6 +70,11 @@ export function eternity(force, auto, specialConditions = {}) {
     // eslint-disable-next-line no-param-reassign
     force = true;
   }
+  // We define this variable so we can use it in checking whether to give
+  // the secret achievement for respec without studies.
+  // Annoyingly, we need to check for studies right here; giveEternityRewards removes studies if we're in an EC,
+  // so doing the check later doesn't give us the initial state of having studies or not.
+  const noStudies = player.timestudy.studies.length === 0;
   if (force) {
     player.challenge.eternity.current = 0;
   } else {
@@ -100,6 +105,9 @@ export function eternity(force, auto, specialConditions = {}) {
   AntimatterDimensions.reset();
 
   if (!specialConditions.enteringEC && player.respec) {
+    if (noStudies) {
+      SecretAchievement(34).unlock();
+    }
     respecTimeStudies(auto);
     player.respec = false;
   }

--- a/javascripts/core/time-studies/time-studies.js
+++ b/javascripts/core/time-studies/time-studies.js
@@ -140,9 +140,6 @@ export function respecTimeStudies(auto) {
   for (const study of TimeStudy.boughtNormalTS()) {
     study.refund();
   }
-  if (player.timestudy.studies.length === 0) {
-    SecretAchievement(34).unlock();
-  }
   player.timestudy.studies = [];
   GameCache.timeStudies.invalidate();
   player.celestials.v.STSpent = 0;


### PR DESCRIPTION
The game has four calls to `respecTimeStudies`; one for reality reset (as part of resetting time studies), one for entering Armageddon (similar to the first), one for exiting an EC, and one for a standard respec. The last of these is the only one that should give the respec secret achievement, IMO.

Thus, we change the respec secret achievement to be checked for in the `eternity` function; at the start of `eternity`, we check if the player has any time studies, and if they didn't have time studies at the start and they do a respec, then we give them the secret achievement.