### PR TITLE
Fix reality animation color

### DIFF
--- a/javascripts/core/reality.js
+++ b/javascripts/core/reality.js
@@ -187,6 +187,8 @@ export function runRealityAnimation() {
   document.getElementById("ui").style.animation = "a-realize 10s 1";
   document.getElementById("realityanimbg").style.animation = "a-realizebg 10s 1";
   document.getElementById("realityanimbg").style.display = "block";
+  if (Theme.current().isDark()) document.getElementById("realityanimbg").style.filter = "invert(1)";
+  else document.getElementById("realityanimbg").style.filter = "";
   setTimeout(() => {
     document.getElementById("realityanimbg").play();
     document.getElementById("realityanimbg").currentTime = 0;

--- a/public/stylesheets/theme-Dark Metro.css
+++ b/public/stylesheets/theme-Dark Metro.css
@@ -24,7 +24,3 @@ body.t-dark-metro {
 .t-dark-metro .c-tt-buy-button--locked:hover {
   background: #e53935;
 }
-
-.t-dark-metro #realityanimbg {
-  filter: invert(1);
-}

--- a/public/stylesheets/theme-Dark.css
+++ b/public/stylesheets/theme-Dark.css
@@ -38,7 +38,3 @@ input.t-dark {
 .t-dark .c-rm-amount__desc {
   color: #757575;
 }
-
-.t-dark #realityanimbg {
-  filter: invert(1);
-}

--- a/public/stylesheets/theme-S10.css
+++ b/public/stylesheets/theme-S10.css
@@ -57,10 +57,6 @@ body.t-s10 {
   color: #999999;
 }
 
-.t-s10 #realityanimbg {
-  filter: invert(1);
-}
-
 .t-s10 .c-alchemy-resource-info {
   color: white;
   border-color: white;

--- a/public/stylesheets/theme-S11.css
+++ b/public/stylesheets/theme-S11.css
@@ -42,10 +42,6 @@ body.t-s11 {
   color: #999999;
 }
 
-.t-s11 #realityanimbg {
-  filter: invert(1);
-}
-
 .t-s11 .c-modal {
   border-color: #e1ae18;
   box-shadow: 0 0 1.5rem 0 black;

--- a/public/stylesheets/theme-S6.css
+++ b/public/stylesheets/theme-S6.css
@@ -57,10 +57,6 @@ body.t-s6 {
   color: #999999;
 }
 
-.t-s6 #realityanimbg {
-  filter: invert(1);
-}
-
 .t-s6 .c-alchemy-resource-info {
   color: white;
   border-color: white;


### PR DESCRIPTION
Fixes #2997.

The animation should now be light/dark based on whether the theme itself is determined to be light or dark, as opposed to being special-cased based on the individual themes. Removed a few CSS filters which became redundant as a result, but the ones in the inverted themes need to stay; this effectively applies the inversion twice in order to keep it colored consistently with the rest of the theme (which is really a light theme with a global color inversion, using the default light animation).