### PR TITLE
Fix double reality rewards

### DIFF
--- a/src/components/modals/prestige/RealityModal.vue
+++ b/src/components/modals/prestige/RealityModal.vue
@@ -64,7 +64,6 @@ export default {
     },
   },
   created() {
-    this.on$(GAME_EVENT.ENTER_PRESSED, () => this.confirmModal(false));
     this.getGlyphs();
     GlyphSelection.realityProps = getRealityProps(false, false);
   },


### PR DESCRIPTION
Fixes #3006. `confirmModal(false)` was already getting called on line 122 of this same file, so putting it in EventHub was making it get called twice.