### PR TITLE
Change no ethical consumption from 5 billion to 2 billion, change banking from 5% to 10%, fixes #3053

### DIFF
--- a/javascripts/core/secret-formula/achievements/normal-achievements.js
+++ b/javascripts/core/secret-formula/achievements/normal-achievements.js
@@ -923,9 +923,9 @@ GameDatabase.achievements.normal = [
     checkRequirement: () => Currency.infinitiesBanked.gt(DC.D2E9),
     checkEvent: [GAME_EVENT.ETERNITY_RESET_AFTER, GAME_EVENT.SAVE_CONVERTED_FROM_PREVIOUS_VERSION],
     get reward() {
-      return `After Eternity you permanently keep ${formatPercents(0.1)} of your Infinities as Banked Infinities.`;
+      return `After Eternity you permanently keep ${formatPercents(0.05)} of your Infinities as Banked Infinities.`;
     },
-    effect: () => Currency.infinities.value.times(0.1).floor()
+    effect: () => Currency.infinities.value.times(0.05).floor()
   },
   {
     id: 132,

--- a/javascripts/core/secret-formula/eternity/time-studies/normal-time-studies.js
+++ b/javascripts/core/secret-formula/eternity/time-studies/normal-time-studies.js
@@ -431,9 +431,9 @@ GameDatabase.eternity.timeStudies.normal = [
     cost: 400,
     requirement: [181, () => EternityChallenge(10).completions > 0],
     reqType: TS_REQUIREMENT_TYPE.ALL,
-    description: () => `After Eternity you permanently keep ${formatPercents(0.1)}
+    description: () => `After Eternity you permanently keep ${formatPercents(0.05)}
     of your Infinities as Banked Infinities`,
-    effect: () => Currency.infinities.value.times(0.1).floor()
+    effect: () => Currency.infinities.value.times(0.05).floor()
   },
   {
     id: 192,


### PR DESCRIPTION
Here's an idea of how this reduces time to get the achievement: A buck savebank save at 1e4000 EP is getting 1.42e8 inf/min; this translates to 1e11 inf (5e9 / 5%, old inf needed for 5e9 banked) in about 12 hours, or 2e10 inf (2e9 / 10%, new inf needed for 5e9 banked) in about 2:20. (Since this save also has e29000 replicanti due to not having been used for a year, it's probably getting something like 10% more infinities than we can expect in practice, but also I might be doing something inefficiently).

This also reduces time to get banked infinities in general, which slightly affects the rest of the game, too. I don't think any celestials depend too much on it, I remember 5x infinities always being the worst reality upgrade all else being equal, and after a while (certainly once you get 1% of your EP per second, in Teresa at I think 1e18 RM), I think you get most of your infinities in your final eternity which makes banked irrelevant.

Also, code-style-wise, `GAME_EVENT.SAVE_CONVERTED_FROM_PREVIOUS_VERSION` isn't used much as a check for things and I'm not sure why; if we're decreasing an achievement requirement, it seems useful, but it could have some hidden issue or something?