### PR TITLE
Increase TP formula

### DIFF
--- a/javascripts/core/dilation.js
+++ b/javascripts/core/dilation.js
@@ -166,7 +166,7 @@ export function getBaseTP(antimatter) {
   if (am.lt(1)) {
     return new Decimal(0);
   }
-  let baseTP = new Decimal(Math.pow(Decimal.log10(am), 1.5) / 8000 + Decimal.log10(am) / 10);
+  let baseTP = new Decimal(Math.pow(Decimal.log10(am), 1.5) / 8000 + (Pelle.isDoomed ? 0 : Decimal.log10(am) / 10));
   if (Enslaved.isRunning) baseTP = baseTP.pow(Enslaved.tachyonNerf);
   return baseTP;
 }
@@ -189,6 +189,11 @@ export function getTachyonReq() {
   const approx = (goal + Math.log(8000)) * (2 / 3);
   if (Math.abs(goal) > 50) {
     return (goal < 0) ? 1 : Decimal.pow10(Math.exp(approx));
+  }
+  // In Pelle, the Tachyon Particle formula only has one term, which we don't
+  // need Newton's method for.
+  if (Pelle.isDoomed) {
+    return Decimal.pow10(Math.exp(approx));
   }
   // There are a number of parameters here we could instead define within the function,
   // but having it take all these as parameters is very convenient for testing it

--- a/src/components/modals/PelleEffectsModal.vue
+++ b/src/components/modals/PelleEffectsModal.vue
@@ -35,6 +35,7 @@ export default {
         // Time studies + Dilation
         "Eternity Upgrade to Time Dimensions based on days played is based on this Armageddon time",
         `All pre-Doomed Dilated Time multipliers are disabled except the ${formatX(2)} buyable`,
+        "The Tachyon Particle formula is worse",
         "All Tachyon Particle multipliers are disabled",
         "All pre-Doomed Time Theorem generation effects are disabled except the Dilation upgrade",
 


### PR DESCRIPTION
This PR adds a term to the TP formula that should "fade out" for the most part by mid-reality, becoming about 1.5x by Teresa reality unlock, but which is 2x-3x for most of pre-reality dilation. It's both a bit big at the start (~5x in first dilation) and a bit big in mid-reality (I would have loved if I could get it down to 1.1x by Teresa unlock), but I think if we want it to be 2x-3x for most of dilation, these things trade off against each other.

It uses Newton's method to calculate AM for more TP because the cubic formula requires complex cube roots, which I don't think JS natively has; I was getting about 10ms for 1000 calls to the "calculate AM for more TP" function in my timing, which seems ok (1/100 of an ms per call). The game did feel laggy, but it always feels laggy on my computer; still, better timing would be appreciated.

Fixes #3054