### PR TITLE
Fix cloud save from multiple devices (?)

### DIFF
--- a/javascripts/core/storage/cloud-saving.js
+++ b/javascripts/core/storage/cloud-saving.js
@@ -78,6 +78,7 @@ export const Cloud = {
       const saveId = GameStorage.currentSlot;
       const cloudSave = root.saves[saveId];
       const thisCloudHash = sha512_256(GameSaveSerializer.serialize(cloudSave));
+      if (!this.lastCloudHash) this.lastCloudHash = thisCloudHash;
       const localSave = GameStorage.saves[saveId];
       const saveComparison = this.compareSaves(cloudSave, localSave, thisCloudHash);
 
@@ -91,8 +92,8 @@ export const Cloud = {
       const hasBoth = cloudSave && localSave;
       // NOTE THIS CHECK IS INTENTIONALLY DIFFERENT FROM THE LOAD CHECK
       const hasConflict = hasBoth && (saveComparison.older === -1 || saveComparison.farther !== 1 ||
-        saveComparison.diffSTD > 0 || saveComparison.differentName || saveComparison.hashMismatch);
-      if (hasConflict && !this.hasSeenSavingConflict) {
+        saveComparison.diffSTD > 0 || saveComparison.differentName);
+      if ((hasConflict && !this.hasSeenSavingConflict) || saveComparison.hashMismatch) {
         Modal.addCloudConflict(saveId, saveComparison, cloudSave, localSave, overwriteAndSendCloudSave);
         Modal.cloudSaveConflict.show();
       } else if (!hasConflict || (this.hasSeenSavingConflict && this.shouldOverwriteCloudSave)) {


### PR DESCRIPTION
After the multiple attempted fixes, I think I have a better sense of the timeline of this feature and what exactly went wrong:
1. Initial implementation (#3008) had an incorrect hash calculation and suppressed the conflict modal after it was seen the first time (both bugs); codewise this seemed like it would implement the feature requested in #3002, but it slipped through (understandably so because it's a lot easier to test this on master, so we basically fast-tracked the PR)
2. The first fix in #3027 was to address the fact that it was getting suppressed - exactly the opposite behavior we'd want for the feature request. This branch, in fact, ended up making the bug in #3037 a lot more visible due to the incorrect hash calculation.
3. #3040 fixed the cloud modal spam, but in doing so also reintroduced the bug the previous PR meant to fix - ie. the conflict modal appeared in the correct situations for all non-hash-related reasons, but was otherwise getting suppressed again.
4. This branch applies the conflict suppression change in #3027 again (as well as what might be a minor related bug), which should work now that the hash is being properly calculated.

I tested it locally with two separate tabs with cloud saving enabled and the cloud save interval temporarily shortened to 15 seconds. The addition on line 81 seemed to make the modal appear properly if you save on one tab and wait for cloud save to trigger on the other tab, but doesn't spam you with the modal if you only have one tab open (all the bugs mentioned by Hira in #3040 should remain fixed). Lines 95-96 should force the modal to appear again if a different device saves now (should properly implement the feature mentioned by Hevi in #3002).

So, that being said, I *think* this should work properly now? I'm still not 100% sure though. Basically tl;dr:
- Initial implementation had bugs A and B
- Bug A was fixed correctly but made bug B more visible (making it seem like the fix was wrong)
- Bug A fix reverted, bug B was fixed
- This branch reapplies the bug A fix again