### PR TITLE
Multiplier tab visual bugs

### DIFF
--- a/javascripts/core/secret-formula/multiplier-tab/antimatter-dimensions.js
+++ b/javascripts/core/secret-formula/multiplier-tab/antimatter-dimensions.js
@@ -10,7 +10,7 @@ GameDatabase.multiplierTabValues.AD = {
   total: {
     name: dim => (dim ? `AD ${dim} Multiplier` : "Base AD Production"),
     displayOverride: dim => {
-      if (dim) return formatX(AntimatterDimension(dim).multiplier, 2);
+      if (dim) return formatX(AntimatterDimension(dim).multiplier, 2, 2);
       const highestDim = AntimatterDimension(
         EternityChallenge(7).isRunning ? 7 : MultiplierTabHelper.activeDimCount("AD")).totalAmount;
       return `${format(AntimatterDimensions.all

--- a/javascripts/core/secret-formula/multiplier-tab/infinity-dimensions.js
+++ b/javascripts/core/secret-formula/multiplier-tab/infinity-dimensions.js
@@ -23,7 +23,8 @@ GameDatabase.multiplierTabValues.ID = {
         .filter(id => id.isProducing)
         .map(id => id.multiplier)
         .reduce((x, y) => x.times(y), DC.D1)),
-    isActive: dim => InfinityDimension(dim ?? 1).isProducing && !EternityChallenge(11).isRunning,
+    isActive: dim => (InfinityDimension(dim ?? 1).isProducing || EternityMilestone.autoUnlockID.isReached) &&
+      !EternityChallenge(11).isRunning,
     dilationEffect: () => {
       const baseEff = player.dilation.active
         ? 0.75 * Effects.product(DilationUpgrade.dilationPenalty)

--- a/javascripts/core/secret-formula/multiplier-tab/tickspeed.js
+++ b/javascripts/core/secret-formula/multiplier-tab/tickspeed.js
@@ -16,7 +16,9 @@ GameDatabase.multiplierTabValues.tickspeed = {
     },
     fakeValue: DC.E100,
     multValue: () => Tickspeed.perSecond.pow(MultiplierTabHelper.activeDimCount("AD")),
-    isActive: true,
+    // No point in showing this breakdown at all unless both components are nonzero; however they will always be nonzero
+    // due to the way the calculation works, so we have to manually hide it here
+    isActive: () => Tickspeed.perSecond.gt(1) && effectiveBaseGalaxies() > 0,
     dilationEffect: () => (Effarig.isRunning ? Effarig.tickDilation : 1),
     overlay: ["<i class='fa-solid fa-clock' />"],
     icon: MultiplierTabIcons.TICKSPEED,

--- a/src/components/tabs/statistics/MultiplierBreakdownEntry.vue
+++ b/src/components/tabs/statistics/MultiplierBreakdownEntry.vue
@@ -179,7 +179,7 @@ export default {
           }
           return this.getProp(this.currentGroupKeys[index], "isBase")
             ? format(x, 2, 2)
-            : `${formatX(x, 2, 2)}`;
+            : formatX(x, 2, 2);
         };
         if (Decimal.neq(this.baseMultList[index], 1)) values.push(formatFn(this.baseMultList[index]));
         if (this.powList[index] !== 1) values.push(formatPow(this.powList[index], 2, 3));


### PR DESCRIPTION
- Fixes #3174 by hiding the tab unless the player both has galaxies and some tickspeed upgrades
- Fixed a couple of formatting bugs
- Fixed ID tab flickering in and out during eternity grinding