### PR TITLE
Fix repeatable hotkeys

### DIFF
--- a/javascripts/core/hotkeys.js
+++ b/javascripts/core/hotkeys.js
@@ -14,6 +14,11 @@ import { GameKeyboard } from "./keyboard";
 // Note: mod is a function key helper by Mousetap for both ctrl and command,
 // and should be used to provide support for both Windows and Max
 
+// Note: DON'T add repeatables with modifier keys other than shift
+// because Mousetrap is crap, and we needed to plug it up to work
+// properly with shift, so you will need to plug it up additionally
+// for the other modifier keys (#3093).
+
 // Free keys:
 // i, j, k, l, n, o, p, q, v, w, x
 

--- a/javascripts/core/keyboard.js
+++ b/javascripts/core/keyboard.js
@@ -1,14 +1,34 @@
 import Mousetrap from "mousetrap";
 
+import { ui } from "./app/ui";
+
 // Add all numpad keys to Mousetrap (keycodes 97-105 correspond to numpad 1-9)
 const numpadKeys = {};
 for (let num = 1; num <= 9; num++) numpadKeys[num + 96] = `num${num}`;
 Mousetrap.addKeycodes(numpadKeys);
 
+function getKeys(combination) {
+  return combination.split("+");
+}
+
+// Extract "a" from "a", "shift+a", "shift+alt+a" and whatever else
+// Returns undefined for mod-only combos, like "shift+alt"
+const modifierKeys = ["ctrl", "shift", "alt", "mod"];
+function getMainKey(keys) {
+  return keys.find(key => !modifierKeys.includes(key));
+}
+
 class KeySpin {
-  constructor(key, action) {
+  constructor(key) {
     this.key = key;
-    this.action = action;
+  }
+
+  setAction(keys, action) {
+    if (keys.includes("shift")) {
+      this.shiftAction = action;
+    } else {
+      this.action = action;
+    }
   }
 
   start() {
@@ -16,12 +36,31 @@ class KeySpin {
       return;
     }
     this.isRunning = true;
-    this.action();
+    this.executeAction();
     this.interval = setInterval(() => {
       clearInterval(this.interval);
-      this.action();
-      this.interval = setInterval(() => this.action(), 40);
+      this.executeAction();
+      this.interval = setInterval(() => this.executeAction(), 40);
     }, 500);
+  }
+
+  executeAction() {
+    if (ui.view.shiftDown && this.shiftAction !== undefined) {
+      this.shiftAction();
+    } else if (this.action !== undefined) {
+      this.action();
+    }
+  }
+
+  probablyStop() {
+    // Goddamn, Mousetrap
+    // It doesn't call keyup "1" for the case where you have "shift+1" pressed,
+    // and you release the "1" key. Instead, it will call the keyup for "shift+1"
+    // To fix this issue, we will stop on "shift+1", but only if we know that
+    // shift is pressed, and that's what's in the ui.view.shiftDown
+    if (ui.view.shiftDown) {
+      this.stop();
+    }
   }
 
   stop() {
@@ -45,7 +84,7 @@ export class GameKeyboard {
   }
 
   static bindRepeatable(key, callback) {
-    this._bindSpin(key, new KeySpin(key, () => executeKey(callback)));
+    this._bindSpin(key, () => executeKey(callback));
   }
 
   static bindHotkey(key, callback, type) {
@@ -53,16 +92,26 @@ export class GameKeyboard {
   }
 
   static bindRepeatableHotkey(key, callback) {
-    this._bindSpin(key, new KeySpin(key, () => executeHotkey(callback)));
+    this._bindSpin(key, () => executeHotkey(callback));
   }
 
-  static _bindSpin(key, spin) {
-    if (spins.find(s => s.key === key)) {
-      throw `Duplicate spin binding for ${key}`;
+  static _bindSpin(combination, action) {
+    const keys = getKeys(combination);
+    const mainKey = getMainKey(keys);
+    let spin = spins.find(s => s.key === mainKey);
+    if (spin === undefined) {
+      spin = new KeySpin(mainKey);
+      spins.push(spin);
+      Mousetrap.bind(mainKey, () => spin.start(), "keydown");
+      Mousetrap.bind(mainKey, () => spin.stop(), "keyup");
     }
-    spins.push(spin);
-    Mousetrap.bind(key, () => spin.start(), "keydown");
-    Mousetrap.bind(key, () => spin.stop(), "keyup");
+
+    if (combination !== mainKey) {
+      Mousetrap.bind(combination, () => spin.start(), "keydown");
+      Mousetrap.bind(combination, () => spin.probablyStop(), "keyup");
+    }
+
+    spin.setAction(keys, action);
   }
 
   static disable() {


### PR DESCRIPTION
Fixes #3093

This fix will make it much harder to add new repeatable hotkeys which use non-shift modifier keys, but not like we are going to add any new ones, eh?

This PR also adds a missing hotkey for shift+numX numpad keys.