### PR TITLE
Lighten cloud save conflict check

### DIFF
--- a/javascripts/core/storage/cloud-saving.js
+++ b/javascripts/core/storage/cloud-saving.js
@@ -110,7 +110,7 @@ export const Cloud = {
       // Bring up the modal if cloud saving will overwrite a cloud save which is older or possibly farther
       const hasBoth = cloudSave && localSave;
       // NOTE THIS CHECK IS INTENTIONALLY DIFFERENT FROM THE LOAD CHECK
-      const hasConflict = hasBoth && saveComparison && (saveComparison.older === -1 || saveComparison.farther !== 1 ||
+      const hasConflict = hasBoth && saveComparison && (saveComparison.older === -1 || saveComparison.farther === -1 ||
         saveComparison.differentName || saveComparison.hashMismatch);
       if (forceModal || (hasConflict && player.options.showCloudModal)) {
         Modal.addCloudConflict(saveId, saveComparison, cloudSave, localSave, overwriteAndSendCloudSave);


### PR DESCRIPTION
Should fix #3209.

The cloud save conflict modal shows up under a few different situations, but one very common one is if it attempts to overwrite the cloud save with a local save that has a *similar* amount of progress. The fuzziness was originally intended, with the assumption that the player would just make the relevant option force the overwrite to hide the modal now that there are more options there. Probably not a good idea to assume that the player will figure out that being the expected usage, so instead the check now only triggers when it could be overwriting a save that's strictly farther. That should make it appear significantly less often and also properly suppress it after a single save like the modal/tooltips suggest. So I think hopefully this should properly stop the unnecessary modal appearances... yet again.

And yes, I did just write a 5-sentence explanation/rationalization for a 2-character change.