### PR TITLE
Fix incorrect description of old saves

### DIFF
--- a/javascripts/core/secret-formula/h2p.js
+++ b/javascripts/core/secret-formula/h2p.js
@@ -35,9 +35,9 @@ cut off part of the text if you are using one to transfer the save between devic
 A properly-formatted save string from the Reality update will start with
 <b>${GameSaveSerializer.startingString.savefile}</b> and end with <b>${GameSaveSerializer.endingString.savefile}</b>.
 If you are importing from a version of the game from before Reality was released, it will instead start with <b>eyJ</b>
-and end with <b>==</b>. If neither of these are the case, then part of your save is missing and it will fail to import.
-In addition to importing and exporting to your clipboard, you can also import and export from text files as well.
-<br>
+and end with <b>In19</b>, <b>fX0=</b>, or <b>fQ==</b>. If neither of these are the case, then part of your save is
+missing and it will fail to import. In addition to importing and exporting to your clipboard, you can also import
+and export from text files as well.
 <br>
 You can use the "Choose save" button to pick between three separate saves on your browser. These saves are, for most
 intents and purposes, completely separate from each other. Importing and exporting will only affect the current save


### PR DESCRIPTION
`btoa` (the old save export method) divides text into blocks of length 3 and turns each block into four characters. Saves always end with `"}}` before btoa. What btoa does to this, however, depends on the offset. The final block could be `"}}` (becoming `In19`), `}}` (becoming `fX0=`), or `}` (becoming `fQ==`). I think one can see all these options at <https://buck4437.github.io/save-bank>.