### PR TITLE
Handle saves with player.options.testVersion even in non-dev builds

### DIFF
--- a/javascripts/core/storage/storage.js
+++ b/javascripts/core/storage/storage.js
@@ -230,7 +230,7 @@ export const GameStorage = {
         // Needed to check some notification about reality unlock study.
         EventHub.dispatch(GAME_EVENT.SAVE_CONVERTED_FROM_PREVIOUS_VERSION);
       }
-      if (DEV) {
+      if (DEV || player.options.testVersion !== undefined) {
         this.devMigrations.patch(player);
       }
     }


### PR DESCRIPTION
Should fix #3226 and all the cross-version save importing issues