### PR TITLE
Migrate Pre-reality Theme

### DIFF
--- a/javascripts/core/storage/migrations.js
+++ b/javascripts/core/storage/migrations.js
@@ -152,6 +152,7 @@ GameStorage.migrations = {
       GameStorage.migrations.etercreqConversion(player);
       GameStorage.migrations.moveTS33(player);
       GameStorage.migrations.addBestPrestigeCurrency(player);
+      GameStorage.migrations.migrateTheme(player);
     }
   },
 
@@ -927,6 +928,10 @@ GameStorage.migrations = {
     player.records.bestReality.bestEP = player.eternityPoints;
     player.records.thisEternity.maxIP = player.infinityPoints;
     player.records.thisReality.maxIP = player.infinityPoints;
+  },
+
+  migrateTheme(player) {
+    player.options.themeClassic = player.options.theme;
   },
 
   prePatch(saveData) {


### PR DESCRIPTION
This was mistakenly done in a dev migration instead of an actual migration (oops) and thus didn't get applied when importing from live saves.

This fix only migrates the imported-save theme as the currently-selected theme, and doesn't add it to the list of selectable themes (ie. it would need to be re-imported again to "properly" unlock it). We can't add it into the options because the way things are currently structured, that would require either storing the theme unlocks in the code as plaintext (I don't think we want that) or reversing the hash function (lolno).