### PR TITLE
Change cloud save check for early reality

### DIFF
--- a/javascripts/core/secret-formula/progress-checker.js
+++ b/javascripts/core/secret-formula/progress-checker.js
@@ -94,7 +94,7 @@ GameDatabase.progressStages = [
     name: "Reality",
     hasReached: save => save.realities > 0,
     suggestedResource: "Reality Machines",
-    subProgressValue: save => Math.sqrt(new Decimal(save.reality.realityMachines).pLog10() / 6),
+    subProgressValue: save => Math.clampMax(save.realities / 100, 1),
   },
   {
     id: PROGRESS_STAGE.TERESA,


### PR DESCRIPTION
Cloud save conflict modal seems to be appearing much more than it should be - "But it seems to think the local save had less progress because I spend the reality machines"

Changed to use reality count instead of RM.