### PR TITLE
Fix automator crash

### DIFF
--- a/javascripts/core/automator/automator-backend.js
+++ b/javascripts/core/automator/automator-backend.js
@@ -859,6 +859,7 @@ export const AutomatorBackend = {
     this.hasJustCompleted = false;
     this.state.topLevelScript = scriptID;
     const scriptObject = this.findScript(scriptID);
+    if (!scriptObject) return;
     if (compile) scriptObject.compile();
     if (scriptObject.commands) {
       this.reset(scriptObject.commands);


### PR DESCRIPTION
This seems to be a fairly big bug that we should try to get in relatively quickly before people start unlocking the automator that we somehow missed in our testing since nobody ever attempted to auto-start a blank script. I suspect we still have a couple days though, because this was uncovered by a save which was clearly console-edited.