### PR TITLE
Fix tickspeed cost increasing in IC5

### DIFF
--- a/javascripts/core/tickspeed.js
+++ b/javascripts/core/tickspeed.js
@@ -87,7 +87,7 @@ export function buyMaxTickSpeed() {
   let boughtTickspeed = false;
 
   Tutorial.turnOffEffect(TUTORIAL_STATE.TICKSPEED);
-  if (NormalChallenge(9).isRunning || InfinityChallenge(5).isRunning) {
+  if (NormalChallenge(9).isRunning) {
     const goal = Player.infinityGoal;
     let cost = Tickspeed.cost;
     while (Currency.antimatter.gt(cost) && cost.lt(goal)) {


### PR DESCRIPTION
There was also a part of the bug report I posted in discord that complained about IC5 description, but for now this just stops tickspeed costs from increasing other costs in IC5.