### PR TITLE
Fix Some Rounding Errors in iM upgrades

### DIFF
--- a/javascripts/core/secret-formula/reality/imaginary-upgrades.js
+++ b/javascripts/core/secret-formula/reality/imaginary-upgrades.js
@@ -146,6 +146,7 @@ GameDatabase.reality.imaginaryUpgrades = [
     name: "Recollection of Intrusion",
     id: 14,
     cost: 3.5e8,
+    formatCost: x => format(x, 1),
     requirement: () => `Reach a tickspeed of ${format("1e75000000000")} / sec within Eternity Challenge 5`,
     hasFailed: () => false,
     checkRequirement: () => EternityChallenge(5).isRunning && Tickspeed.perSecond.exponent >= 7.5e10,


### PR DESCRIPTION
This has existed for ages

Someone forgot a `formatCost: x => format(x, 1),`