### PR TITLE
Fix some issues found for mid-February patch

### DIFF
--- a/src/components/tabs/statistics/StatisticsTab.vue
+++ b/src/components/tabs/statistics/StatisticsTab.vue
@@ -183,6 +183,7 @@ export default {
         You have {{ quantifyInt("useless paperclip", paperclips) }}.
       </div>
       <div v-if="fullGameCompletions">
+        <br>
         <b>
           You have completed the entire game {{ quantifyInt("time", fullGameCompletions) }}.
           <br>

--- a/src/components/ui-modes/prestige-header/RealityButton.vue
+++ b/src/components/ui-modes/prestige-header/RealityButton.vue
@@ -100,8 +100,8 @@ export default {
       this.ppGained = multiplier;
       this.shardsGained = Effarig.shardsGained * multiplier;
       this.currentShardsRate = (this.shardsGained / Time.thisRealityRealTime.totalMinutes);
-      this.bestShardRate = player.records.thisReality.bestRSmin;
-      this.bestShardRateVal = player.records.thisReality.bestRSminVal;
+      this.bestShardRate = player.records.thisReality.bestRSmin * multiplier;
+      this.bestShardRateVal = player.records.thisReality.bestRSminVal * multiplier;
 
       const teresaReward = this.formatScalingMultiplierText(
         "Glyph Sacrifice",

--- a/src/core/autobuyers/reality-autobuyer.js
+++ b/src/core/autobuyers/reality-autobuyer.js
@@ -77,7 +77,10 @@ Autobuyer.reality = new class RealityAutobuyerState extends AutobuyerState {
 
   tick() {
     let proc = false;
-    const rmProc = MachineHandler.gainedRealityMachines.gte(this.rm);
+    // The game generally displays amplified values, so we want to adjust the thresholds to
+    // account for that and make the automation trigger based on the actual displayed values
+    const ampFactor = simulatedRealityCount(false) + 1;
+    const rmProc = MachineHandler.gainedRealityMachines.times(ampFactor).gte(this.rm);
     const glyphProc = gainedGlyphLevel().actualLevel >= Math.min(this.glyph, Glyphs.levelCap);
     switch (this.mode) {
       case AUTO_REALITY_MODE.RM:
@@ -96,7 +99,7 @@ Autobuyer.reality = new class RealityAutobuyerState extends AutobuyerState {
         proc = player.records.thisReality.realTime / 1000 > this.time;
         break;
       case AUTO_REALITY_MODE.RELIC_SHARD:
-        proc = Effarig.shardsGained > this.shard;
+        proc = Effarig.shardsGained * ampFactor > this.shard;
         break;
     }
     if (proc) autoReality();

--- a/src/core/autobuyers/time-dimension-autobuyer.js
+++ b/src/core/autobuyers/time-dimension-autobuyer.js
@@ -34,8 +34,12 @@ class TimeDimensionAutobuyerState extends IntervaledAutobuyerState {
   }
 
   tick() {
+    // We specifically call these two things before actually running the TD autobuyer code because that behavior
+    // is desirable to gameplay, but simply reordering the autobuyers overall has undesired side-effects. There
+    // are checks internal to these calls which ensure that they don't trigger even when still locked
     applyEU2();
     Autobuyer.epMult.tick();
+
     const tier = this.tier;
     if (!TimeDimension(tier).isAvailableForPurchase) return;
     super.tick();

--- a/src/core/reality.js
+++ b/src/core/reality.js
@@ -271,7 +271,7 @@ function updateRealityRecords(realityProps) {
 function giveRealityRewards(realityProps) {
   const multiplier = realityProps.simulatedRealities + 1;
   const realityAndPPMultiplier = multiplier + binomialDistribution(multiplier, Achievement(154).effectOrDefault(0));
-  const gainedRM = realityProps.gainedRM;
+  const gainedRM = Currency.realityMachines.gte(MachineHandler.hardcapRM) ? DC.D0 : realityProps.gainedRM;
   Currency.realityMachines.add(gainedRM.times(multiplier));
   updateRealityRecords(realityProps);
   addRealityTime(
@@ -679,6 +679,8 @@ export function finishProcessReality(realityProps) {
   player.records.thisEternity.bestIPMsWithoutMaxAll = DC.D0;
   player.records.bestEternity.bestEPminReality = DC.D0;
   player.records.thisReality.bestEternitiesPerMs = DC.D0;
+  player.records.thisReality.bestRSmin = 0;
+  player.records.thisReality.bestRSminVal = 0;
   resetTimeDimensions();
   resetTickspeed();
   AchievementTimers.marathon2.reset();

--- a/src/core/secret-formula/celestials/navigation.js
+++ b/src/core/secret-formula/celestials/navigation.js
@@ -638,7 +638,7 @@ GameDatabase.celestials.navigation = {
             `Reach Glyph rarity ${formatPercents(complete * goal / 100, 1)}/${formatPercents(goal / 100, 1)}`
           ];
         },
-        angle: 135,
+        angle: 45,
         diagonal: 32,
         horizontal: 32,
       },

--- a/src/core/secret-formula/shop-purchases.js
+++ b/src/core/secret-formula/shop-purchases.js
@@ -8,7 +8,7 @@ GameDatabase.shopPurchases = {
     cost: 30,
     description: "Double all your Antimatter Dimension multipliers. Forever.",
     multiplier: purchases => Math.pow(2, purchases),
-    formatEffect: x => `×${Notation.scientific.formatDecimal(new Decimal(x))}`,
+    formatEffect: x => `×${x > 1000 ? Notation.scientific.formatDecimal(new Decimal(x), 2) : x.toFixed(0)}`,
   },
   allDimPurchases: {
     key: "allDimPurchases",

--- a/src/game.js
+++ b/src/game.js
@@ -1,5 +1,6 @@
-import { ElectronRuntime, SteamRuntime } from "@/steam";
 import TWEEN from "tween.js";
+
+import { ElectronRuntime, SteamRuntime } from "@/steam";
 
 import { DC } from "./core/constants";
 import { deepmergeAll } from "@/utility/deepmerge";
@@ -258,7 +259,8 @@ export function addRealityTime(time, realTime, rm, level, realities) {
   }
   const shards = Effarig.shardsGained;
   player.records.recentRealities.pop();
-  player.records.recentRealities.unshift([time, realTime, rm, realities, reality, level, shards]);
+  player.records.recentRealities.unshift([time, realTime, rm.times(realities), realities,
+    reality, level, shards * realities]);
 }
 
 export function gainedInfinities() {


### PR DESCRIPTION
Found a few things when retesting:
- Relic shard rate wasn't being reset on reality, so RS/min text was being incorrect
- Some modes for auto-reality weren't consistently accounting for amplification, while generally displayed values always were
- Some resources in last 10 prestige records weren't accounting for amplification and RM cap
- Navigation for cel3 had a UI overlap issue
- AD mult in Shop was displaying weirdly in terms of decimal places