### PR TITLE
Fix glyph seed not advancing on auto-reality

### DIFF
--- a/src/core/reality.js
+++ b/src/core/reality.js
@@ -364,7 +364,6 @@ export function beginProcessReality(realityProps) {
         GlyphSelection.select(Math.floor(Math.random() * GlyphSelection.choiceCount), false);
       }
     }
-    rng.finalize();
     Glyphs.processSortingAfterReality();
     return;
   }


### PR DESCRIPTION
Our glyph RNG code is a mess and at this point I'm not entirely sure if it's due to bad program flow or just raw complexity, but I'm more willing to believe it's the former. Either way, I'm not 100% convinced that the fix to this is as simple as just removing a single `finalize()` call and that that wouldn't cause any additional bad side-effects, so I'd like a sanity check from someone else on this if possible. As far as I can tell, glyphs were being generated just fine but then the extra call was resetting the seed again _after_ the glyph(s) were processed.

Discord post for context: https://discord.com/channels/351476683016241162/1078690420525109349