### PR TITLE
7-23 fixes

### DIFF
--- a/src/components/modals/StudyStringModal.vue
+++ b/src/components/modals/StudyStringModal.vue
@@ -177,8 +177,7 @@ export default {
         if (this.respecAndLoad && Player.canEternity) {
           player.respec = true;
           const tree = new TimeStudyTree(this.truncatedInput);
-          animateAndEternity(() =>
-            TimeStudyTree.commitToGameState(tree.purchasedStudies, false, this.combinedTree.startEC));
+          animateAndEternity(() => TimeStudyTree.commitToGameState(tree.purchasedStudies, false, tree.startEC));
           return;
         }
         this.importTree();

--- a/src/components/modals/options/glyph-appearance/GlyphDisplayOptionsModal.vue
+++ b/src/components/modals/options/glyph-appearance/GlyphDisplayOptionsModal.vue
@@ -103,66 +103,78 @@ export default {
 </script>
 
 <template>
-  <ModalWrapperOptions class="c-modal-options__large">
+  <ModalWrapperOptions class="c-modal-options__glyph">
     <template #header>
       Glyph Display Options
     </template>
-    <div class="c-modal-options__button-container">
-      <ModalOptionsToggleButton
-        v-model="newGlyphs"
-        text="New Glyph identifier:"
-      />
-      <ModalOptionsToggleButton
-        v-model="showUnequippedGlyphIcon"
-        text="Unequipped Glyph identifier:"
-      />
-      <ModalOptionsToggleButton
-        v-model="glyphEffectDots"
-        text="Always show Glyph effect dots:"
-      />
-      <ModalOptionsToggleButton
-        v-model="glyphBorders"
-        text="Fancy Glyph borders:"
-      />
-      <button
-        class="o-primary-btn o-primary-btn--modal-option"
-        @click="cycleBG()"
-      >
-        Glyph BG color: {{ glyphBGStr }}
-      </button>
-      <ModalOptionsToggleButton
-        v-model="showGlyphInfoByDefault"
-        :style="noEffectStyle()"
-        text="Always show Glyph Info:"
-      />
-      <ModalOptionsToggleButton
-        v-model="highContrastRarity"
-        text="High-contrast rarity colors:"
-      />
-      <ModalOptionsToggleButton
-        v-model="swapGlyphColors"
-        text="Swap border and symbol colors:"
-      />
-      <ExpandingControlBox
-        class="o-primary-btn c-dropdown-btn"
-      >
-        <template #header>
-          <div class="c-dropdown-header">
-            ▼ Additional Glyph Info: ▼
-            <br>
-            {{ infoLabel }}
-          </div>
-        </template>
-        <template #dropdown>
-          <SelectGlyphInfoDropdown />
-        </template>
-      </ExpandingControlBox>
+    <div class="c-glyph-visual-options c-modal--short">
+      <div class="c-modal-options__button-container">
+        <ModalOptionsToggleButton
+          v-model="newGlyphs"
+          text="New Glyph identifier:"
+        />
+        <ModalOptionsToggleButton
+          v-model="showUnequippedGlyphIcon"
+          text="Unequipped Glyph identifier:"
+        />
+        <ModalOptionsToggleButton
+          v-model="glyphEffectDots"
+          text="Always show Glyph effect dots:"
+        />
+        <ModalOptionsToggleButton
+          v-model="glyphBorders"
+          text="Fancy Glyph borders:"
+        />
+        <button
+          class="o-primary-btn o-primary-btn--modal-option"
+          @click="cycleBG()"
+        >
+          Glyph BG color: {{ glyphBGStr }}
+        </button>
+        <ModalOptionsToggleButton
+          v-model="showGlyphInfoByDefault"
+          :style="noEffectStyle()"
+          text="Always show Glyph Info:"
+        />
+        <ModalOptionsToggleButton
+          v-model="highContrastRarity"
+          text="High-contrast rarity colors:"
+        />
+        <ModalOptionsToggleButton
+          v-model="swapGlyphColors"
+          text="Swap border and symbol colors:"
+        />
+        <ExpandingControlBox
+          class="o-primary-btn c-dropdown-btn"
+        >
+          <template #header>
+            <div class="c-dropdown-header">
+              ▼ Additional Glyph Info: ▼
+              <br>
+              {{ infoLabel }}
+            </div>
+          </template>
+          <template #dropdown>
+            <SelectGlyphInfoDropdown />
+          </template>
+        </ExpandingControlBox>
+      </div>
+      <GlyphCustomization />
     </div>
-    <GlyphCustomization />
   </ModalWrapperOptions>
 </template>
 
 <style scoped>
+.c-modal-options__glyph {
+  width: 55rem;
+}
+
+.c-glyph-visual-options {
+  width: 55rem;
+  overflow-x: hidden;
+  padding-right: 1rem;
+}
+
 .c-dropdown-btn {
   width: 24rem;
   margin: 0.3rem;

--- a/src/components/modals/prestige/EnterDilationModal.vue
+++ b/src/components/modals/prestige/EnterDilationModal.vue
@@ -33,11 +33,12 @@ export default {
     handleYesClick() {
       if (player.dilation.active) return;
       if (player.options.animations.dilation && !FullScreenAnimationHandler.isDisplaying) {
+        // Strike trigger happens within the delayed dilation callback in this function
         animateAndDilate();
       } else {
         startDilatedEternity();
+        if (Pelle.isDoomed) PelleStrikes.dilation.trigger();
       }
-      if (Pelle.isDoomed) PelleStrikes.dilation.trigger();
     },
   },
 };

--- a/src/components/modals/prestige/ExitDilationModal.vue
+++ b/src/components/modals/prestige/ExitDilationModal.vue
@@ -21,6 +21,9 @@ export default {
     },
     isInEC() {
       return Player.anyChallenge instanceof EternityChallengeState;
+    },
+    confirmText() {
+      return this.isDoomed ? "Okay" : "Exit";
     }
   },
   methods: {
@@ -59,8 +62,7 @@ export default {
     </template>
     <div class="c-modal-message__text">
       <span v-if="isDoomed">
-        Dilation is permanent. You will {{ gainText }} and reset your current eternity. You will not gain any
-        Eternity Points.
+        Dilation is permanent. You will {{ gainText }} and reset your current Eternity.
       </span>
       <span v-else>
         If you exit Dilation now, you will {{ gainText }}.
@@ -72,7 +74,7 @@ export default {
       Are you sure you want to proceed?
     </div>
     <template #confirm-text>
-      Exit
+      {{ confirmText }}
     </template>
   </ModalWrapperChoice>
 </template>

--- a/src/core/celestials/pelle/pelle.js
+++ b/src/core/celestials/pelle/pelle.js
@@ -267,6 +267,18 @@ export const Pelle = {
     return this.cel.remnants >= this.remnantRequirementForDilation;
   },
 
+  resetResourcesForDilation() {
+    this.cel.records.totalAntimatter = new Decimal("1e180000");
+    this.cel.records.totalInfinityPoints = new Decimal("1e60000");
+    Currency.eternityPoints.reset();
+    // Oddly specific number? Yes, it's roughly the amount of EP you have
+    // when starting dilation for the first time
+    // Since 5th strike previously did not reset your current EP the previous reset value was kind of useless which
+    // lead to some balancing problems, this hopefully prevents people starting dilation too early and getting
+    // softlocked, or starting it too late and getting not-softlocked.
+    this.cel.records.totalEternityPoints = new Decimal("1e1050");
+  },
+
   get remnantsGain() {
     let am = this.cel.records.totalAntimatter.plus(1).log10();
     let ip = this.cel.records.totalInfinityPoints.plus(1).log10();

--- a/src/core/celestials/pelle/strikes.js
+++ b/src/core/celestials/pelle/strikes.js
@@ -39,17 +39,7 @@ class PelleStrikeState extends BitUpgradeState {
     player.celestials.pelle.collapsed.rifts = false;
 
     // If it's paradox, reset the records
-    if (this.id === 5) {
-      Pelle.cel.records.totalAntimatter = new Decimal("1e180000");
-      Pelle.cel.records.totalInfinityPoints = new Decimal("1e60000");
-      Currency.eternityPoints.reset();
-      // Oddly specific number? Yes, it's roughly the amount of EP you have
-      // when starting dilation for the first time
-      // Since 5th strike previously did not reset your current EP the previous reset value was kind of useless which
-      // lead to some balancing problems, this hopefully prevents people starting dilation too early and getting
-      // softlocked, or starting it too late and getting not-softlocked.
-      Pelle.cel.records.totalEternityPoints = new Decimal("1e1050");
-    }
+    if (this.id === 5) Pelle.resetResourcesForDilation();
     Tab.celestials.pelle.show();
     EventHub.dispatch(GAME_EVENT.PELLE_STRIKE_UNLOCKED);
   }

--- a/src/core/dilation.js
+++ b/src/core/dilation.js
@@ -5,7 +5,10 @@ import { SpeedrunMilestones } from "./speedrun";
 
 export function animateAndDilate() {
   FullScreenAnimationHandler.display("a-dilate", 2);
-  setTimeout(startDilatedEternity, 1000);
+  setTimeout(() => {
+    startDilatedEternity();
+    if (Pelle.isDoomed) PelleStrikes.dilation.trigger();
+  }, 1000);
 }
 
 // eslint-disable-next-line no-empty-function

--- a/src/core/new-game.js
+++ b/src/core/new-game.js
@@ -56,6 +56,7 @@ export const NG = {
     // which could lead to some edge cases where it starts when it shouldn't (ie before it's unlocked)
     // It's easier to do something like this to avoid it entirely.
     const automatorConstants = JSON.stringify(player.reality.automator.constants);
+    const automatorConstantSort = JSON.stringify(player.reality.automator.constantSortOrder);
     const automatorScripts = JSON.stringify(player.reality.automator.scripts);
     const fullCompletions = player.records.fullGameCompletions;
     const fullTimePlayed = player.records.previousRunRealTime + player.records.realTimePlayed;
@@ -72,6 +73,7 @@ export const NG = {
     player.secretUnlocks = secretUnlocks;
     player.secretAchievementBits = JSON.parse(secretAchievements);
     player.reality.automator.constants = JSON.parse(automatorConstants);
+    player.reality.automator.constantSortOrder = JSON.parse(automatorConstantSort);
     player.reality.automator.scripts = JSON.parse(automatorScripts);
     player.records.fullGameCompletions = fullCompletions;
     player.records.previousRunRealTime = fullTimePlayed;

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -359,7 +359,7 @@ window.player = {
     previousRuns: {}
   },
   IPMultPurchases: 0,
-  version: 23,
+  version: 24,
   infinityPower: DC.D1,
   postC4Tier: 0,
   eternityPoints: DC.D0,

--- a/src/core/storage/migrations.js
+++ b/src/core/storage/migrations.js
@@ -404,6 +404,13 @@ export const migrations = {
         }
       }
     },
+    24: player => {
+      // Automator constants didn't copy over properly across new games - retroactively fix bugged saves as well
+      const definedConstants = Object.keys(player.reality.automator.constants);
+      if (definedConstants.length !== player.reality.automator.constantSortOrder.length) {
+        player.reality.automator.constantSortOrder = [...definedConstants];
+      }
+    },
   },
 
   normalizeTimespans(player) {

--- a/src/core/time-studies/time-study-tree.js
+++ b/src/core/time-studies/time-study-tree.js
@@ -240,7 +240,8 @@ export class TimeStudyTree {
       if (checkOnlyStructure) {
         return reqSatisfied && !hasForbiddenStudies;
       }
-      const hasEnoughTT = Currency.timeTheorems.value.subtract(this.spentTheorems[0]).gte(study.cost);
+      const totalTT = player.timestudy.theorem.plus(TimeTheorems.calculateTimeStudiesCost());
+      const hasEnoughTT = totalTT.subtract(this.spentTheorems[0]).gte(study.cost);
       const secondaryGoal = Perk.studyECRequirement.isBought || study.isEntryGoalMet;
       return reqSatisfied && !hasForbiddenStudies && (study.isBought || (secondaryGoal && hasEnoughTT));
     }


### PR DESCRIPTION
Changes here:
- Limited height of "Glyph Visual Options" modal to prevent screen cuttoffs (now has a vertical scrollbar)
- Fixed remnant count not being properly reset when entering cel7 dilation with animation on (animation callback delay was making the strike and resource reset trigger in the wrong order)
- Fixed wording on cel7 dilation modal claiming that EP won't be gained (this was a late-development change we missed changing the wording for)
- Fixed constant data not being properly carried over on full completion and migrated data on saves affected by this bug
- Fixed EC TT cost being calculated incorrectly when using EC! functionality and tree respec simultaneously