### PR TITLE
Fix automator pause command ticking wrongly

### DIFF
--- a/src/core/automator/automator-commands.js
+++ b/src/core/automator/automator-commands.js
@@ -401,7 +401,7 @@ export const AutomatorCommands = [
           S.commandState = { timeMs: 0 };
           AutomatorData.logCommandEvent(`Pause started (waiting ${timeString})`, ctx.startLine);
         } else {
-          S.commandState.timeMs += Math.max(Time.unscaledDeltaTime.milliseconds, AutomatorBackend.currentInterval);
+          S.commandState.timeMs += Math.max(Time.unscaledDeltaTime.totalMilliseconds, AutomatorBackend.currentInterval);
         }
         const finishPause = S.commandState.timeMs >= duration;
         if (finishPause) {


### PR DESCRIPTION
The original code use the `milliseconds` method which means remain milliseconds besides full seconds. However, the automator obviously should tick by total milliseconds passed. So it would cause unexpected behavior with tick longer than 1s. (maybe happen when calculating offline progress)
The `totalMilliseconds` method means total milliseconds, as expected.