### PR TITLE
Update autobuyers values on enter (fixes #1278)

### DIFF
--- a/src/components/tabs/autobuyers/AutobuyerInput.vue
+++ b/src/components/tabs/autobuyers/AutobuyerInput.vue
@@ -69,7 +69,7 @@ export default {
     handleFocus() {
       this.isFocused = true;
     },
-    updateAutobuyerValue() {
+    handleChange(event) {
       if (this.displayValue === "69") {
         SecretAchievement(28).unlock();
       }
@@ -80,10 +80,9 @@ export default {
       }
       this.updateDisplayValue();
       this.isValid = true;
-    },
-    handleBlur() {
-      this.updateActualValue();
+
       this.isFocused = false;
+      event.target.blur();
     },
   }
 };
@@ -145,8 +144,7 @@ export const AutobuyerInputFunctions = {
     :class="validityClass"
     :type="inputType"
     class="o-autobuyer-input"
-    @blur="handleBlur"
-    @change="updateAutobuyerValue"
+    @change="handleChange"
     @focus="handleFocus"
     @input="handleInput"
   >

--- a/src/components/tabs/autobuyers/AutobuyerInput.vue
+++ b/src/components/tabs/autobuyers/AutobuyerInput.vue
@@ -69,7 +69,7 @@ export default {
     handleFocus() {
       this.isFocused = true;
     },
-    handleBlur() {
+    updateAutobuyerValue() {
       if (this.displayValue === "69") {
         SecretAchievement(28).unlock();
       }
@@ -80,8 +80,11 @@ export default {
       }
       this.updateDisplayValue();
       this.isValid = true;
+    },
+    handleBlur() {
+      this.updateActualValue();
       this.isFocused = false;
-    }
+    },
   }
 };
 
@@ -143,6 +146,7 @@ export const AutobuyerInputFunctions = {
     :type="inputType"
     class="o-autobuyer-input"
     @blur="handleBlur"
+    @change="updateAutobuyerValue"
     @focus="handleFocus"
     @input="handleInput"
   >


### PR DESCRIPTION
Note that this pull request currently solves the main issue of using the enter key to confirm the current selection, however, doesn't include the escape button to "undo" the unsaved text. I can implement this if it would be helpful, but I feel like it may not be intuitive so it would need to be documented somewhere if added. 