### PR TITLE
Fix Tachyon particles being white on Metro theme, and thus invisible

### DIFF
--- a/public/stylesheets/theme-Metro.css
+++ b/public/stylesheets/theme-Metro.css
@@ -18,3 +18,7 @@
 .t-metro .c-tt-buy-button--locked:hover {
   background: #ef5350;
 }
+
+.o-tachyon-particle {
+  fill: black !important;
+}


### PR DESCRIPTION
Inverts the colour of the tachyon particles animation in the time dilation tab, making them visible.