### PR TITLE
Fix automator bug with UNTIL PRESTIGE

### DIFF
--- a/src/core/automator/automator-backend.js
+++ b/src/core/automator/automator-backend.js
@@ -1030,6 +1030,9 @@ export const AutomatorBackend = {
       this._data = [];
       player.reality.automator.state.stack.length = 0;
     },
+    forEach(fn) {
+      this._data.forEach(fn);
+    },
     initializeFromSave(commands) {
       this._data = [];
       const playerStack = player.reality.automator.state.stack;

--- a/src/core/automator/automator-commands.js
+++ b/src/core/automator/automator-commands.js
@@ -9,10 +9,14 @@ const idSplitter = /id[ \t]+(\d)/ui;
 
 function prestigeNotify(flag) {
   if (!AutomatorBackend.isOn) return;
-  const state = AutomatorBackend.stack.top.commandState;
+
+  // Any frame in the stack may be waiting for a prestige event, so update all of them.
+  AutomatorBackend.stack.forEach(frame => {
+    const state = frame.commandState;
   if (state && state.prestigeLevel !== undefined) {
     state.prestigeLevel = Math.max(state.prestigeLevel, flag);
   }
+  });
 }
 
 EventHub.logic.on(GAME_EVENT.BIG_CRUNCH_AFTER, () => prestigeNotify(T.Infinity.$prestigeLevel));


### PR DESCRIPTION
Prestige events are delivered to the commandState of the top stack frame, but loop bodies execute in their own stack frame. This means that prestige events only reach the `UNTIL` command during the same automator tick where the loop condition is being evaluated.

In practice this means that, say, `UNTIL ETERNITY` loops will "miss" any eternities that happen during execution of one of the commands inside the loop. This has been observed in bug report
https://discord.com/channels/351476683016241162/1080463168121352202

The fix is to update `commandState` for *each* frame in the stack any time there is a prestige event. I added a `forEach` to the stack structure so that we could apply the same logic to all frames. Performance impact should not be noticeable, assuming that if/while/until are not too deeply nested. 😅

An alternative fix I considered was to copy some `commandState` values from one frame to another during `AutomatorBackend.nextCommand()`. However, the frame's `commandState` is completely reset between commands, and leaking state between them seemed fraught.