### PR TITLE
Improved Continuum performance

### DIFF
--- a/src/core/dimensions/antimatter-dimension.js
+++ b/src/core/dimensions/antimatter-dimension.js
@@ -525,9 +525,10 @@ class AntimatterDimensionState extends DimensionState {
   }
 
   get isAvailableForPurchase() {
-    if (!EternityMilestone.unlockAllND.isReached && this.tier > DimBoost.totalBoosts + 4) return false;
+    if (EternityMilestone.unlockAllND.isReached) return this.tier < 7 || !NormalChallenge(10).isRunning;
+    if (this.tier > DimBoost.purchasedBoosts + 4) return false;
     const hasPrevTier = this.tier === 1 || AntimatterDimension(this.tier - 1).totalAmount.gt(0);
-    if (!EternityMilestone.unlockAllND.isReached && !hasPrevTier) return false;
+    if (!hasPrevTier) return false;
     return this.tier < 7 || !NormalChallenge(10).isRunning;
   }
 


### PR DESCRIPTION
To get the Continuum value of a Dimension it first checks if it's available for purchase. However, because the function `isAvailableForPurchase()` calculates its local variable `hasPrevTier` despite its value not being relevant if the Eternity Milestone is unlocked, this generates a long, unnecessary chain of commands that goes like `(tier - 1).totalAmount` -> `continuumAmount` -> `continuumValue` -> `isAvailableForPurchase` -> (...) for all 8 tiers if we start from AD 8. This only happens if Continuum is enabled, so if we check and return for the Eternity Milestone first, which can be safely assumed it's permanently unlocked at this point of the game, this shouldn't happen.