### PR TITLE
Fix Remnant gain factors while Dilated and Doomed

### DIFF
--- a/src/components/tabs/celestial-pelle/RemnantGainFactor.vue
+++ b/src/components/tabs/celestial-pelle/RemnantGainFactor.vue
@@ -102,10 +102,10 @@ export default {
                 {{ format(Math.log10(best.am.add(1).log10()*dilationMult[0] + 2), 2, 2) }}
               </div>
               <div class="l-remnant-factors-item">
-                {{ format(Math.log10(best.ip.add(1).log10()*dilationMult[0] + 2), 2, 2) }}
+                {{ format(Math.log10(best.ip.add(1).log10()*dilationMult[1] + 2), 2, 2) }}
               </div>
               <div class="l-remnant-factors-item">
-                {{ format(Math.log10(best.ep.add(1).log10()*dilationMult[0] + 2), 2, 2) }}
+                {{ format(Math.log10(best.ep.add(1).log10()*dilationMult[2] + 2), 2, 2) }}
               </div>
               <div class="l-remnant-factors-item">
                 {{ format(1.64, 2, 2) }}


### PR DESCRIPTION
Remnant gain while Dilated and Doomed was visually calculated incorrectly: when calculating the numbers in the rightmost column, the multiplier used on `log10(ip)` and `log10(ep)` was the same as the multiplier on `log10(am)` instead of the correct values given on the leftmost column.