### PR TITLE
Fixed tiny visual glitch of ECB while its closed

### DIFF
--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -2816,8 +2816,8 @@ br {
   background-color: var(--color-base);
   border: 0.1rem var(--color-good);
   border-style: solid;
-  border-radius: var(--var-border-radius, 0.4rem);
   border-top-color: transparent;
+  border-radius: var(--var-border-radius, 0.4rem);
 }
 
 /* We need scrollbar-color in this rule as well as identical color specifications in the following two; some

--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -2817,8 +2817,6 @@ br {
   border: 0.1rem var(--color-good);
   border-style: solid;
   border-radius: var(--var-border-radius, 0.4rem);
-  /* May be removed if it makes things to blurry */
-  transform: translateY(-0.1rem);
 }
 
 /* We need scrollbar-color in this rule as well as identical color specifications in the following two; some

--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -2817,6 +2817,7 @@ br {
   border: 0.1rem var(--color-good);
   border-style: solid;
   border-radius: var(--var-border-radius, 0.4rem);
+  border-top-color: transparent;
 }
 
 /* We need scrollbar-color in this rule as well as identical color specifications in the following two; some


### PR DESCRIPTION
ExpandingControlBox's inner content was very slightly visible while its in the closed state.
I tried to fix that.

Tested with: Chrome 121.0.6167.161, Windows 11, 2880x1920 (175%)

Before:
![image](https://github.com/IvarK/AntimatterDimensionsSourceCode/assets/56225774/b25e6775-efaa-4e8b-831a-4f1b1dc4204f)
After:
![image](https://github.com/IvarK/AntimatterDimensionsSourceCode/assets/56225774/2324dc3e-398a-49b4-9492-9ef396ebfb63)
