### PR TITLE
Add reset all tabs button in tab modify modal

### DIFF
--- a/src/components/modals/options/hidden-tabs/HiddenTabsModal.vue
+++ b/src/components/modals/options/hidden-tabs/HiddenTabsModal.vue
@@ -1,12 +1,14 @@
 <script>
 import HiddenTabGroup from "@/components/modals/options/hidden-tabs/HiddenTabGroup";
 import ModalWrapperOptions from "@/components/modals/options/ModalWrapperOptions";
+import PrimaryButton from "@/components/PrimaryButton";
 
 export default {
   name: "HiddenTabsModal",
   components: {
     HiddenTabGroup,
     ModalWrapperOptions,
+    PrimaryButton,
   },
   data() {
     return {
@@ -22,6 +24,13 @@ export default {
       this.isEnslaved = Enslaved.isRunning;
       this.isAlmostEnd = Pelle.hasGalaxyGenerator;
     },
+    resetAllTabs() {
+      for (const tab of this.tabs) {
+        tab.unhideTab();
+        for (const subtab of tab.subtabs)
+          subtab.unhideTab();
+      }
+    }
   },
 };
 </script>
@@ -48,6 +57,11 @@ export default {
         <br>
         (You cannot hide your tabs within this Reality)
       </div>
+      <PrimaryButton
+        @click="resetAllTabs"
+      >
+        Reset all tabs
+      </PrimaryButton>
       <HiddenTabGroup
         v-for="(tab, index) in tabs"
         :key="index"

--- a/src/components/modals/options/hidden-tabs/HiddenTabsModal.vue
+++ b/src/components/modals/options/hidden-tabs/HiddenTabsModal.vue
@@ -24,7 +24,7 @@ export default {
       this.isEnslaved = Enslaved.isRunning;
       this.isAlmostEnd = Pelle.hasGalaxyGenerator;
     },
-    resetAllTabs() {
+    showAllTabs() {
       for (const tab of this.tabs) {
         tab.unhideTab();
         for (const subtab of tab.subtabs)
@@ -58,9 +58,9 @@ export default {
         (You cannot hide your tabs within this Reality)
       </div>
       <PrimaryButton
-        @click="resetAllTabs"
+        @click="showAllTabs"
       >
-        Reset all tabs
+        Show all tabs
       </PrimaryButton>
       <HiddenTabGroup
         v-for="(tab, index) in tabs"


### PR DESCRIPTION
Added a `Reset all tabs` button in the Modify Visible Tabs modal.
This is convenient when I found an imported save has hidden tabs and I want to show all of them quickly.

![image](https://github.com/IvarK/AntimatterDimensionsSourceCode/assets/56225774/bcf8378a-f30f-45d7-9b39-fb02f73ace4e)
