### PR TITLE
Fix Glyph Popup Rarity color

### DIFF
--- a/src/components/GlyphTooltip.vue
+++ b/src/components/GlyphTooltip.vue
@@ -128,7 +128,7 @@ export default {
       if (!GlyphTypes[this.type].hasRarity) return "";
       const strength = Pelle.isDoomed ? Pelle.glyphStrength : this.strength;
       return `| Rarity:
-        <span style="color: ${this.rarityInfo.color}">${formatRarity(strengthToRarity(strength))}</span>`;
+        <span style="color: ${this.descriptionStyle.color}">${formatRarity(strengthToRarity(strength))}</span>`;
     },
     levelText() {
       if (this.type === "companion") return "";


### PR DESCRIPTION
Fix Glyph popup Rarity color. It was always black/white because `this.rarityInfo.color` does not exist.
Credit to Hexa and Donaldino for the detailed bug report on Discord ❤️ 

Before:
![image](https://github.com/IvarK/AntimatterDimensionsSourceCode/assets/56225774/26d726cf-8064-446c-990a-8f4af1d4f96f)
After:
![image](https://github.com/IvarK/AntimatterDimensionsSourceCode/assets/56225774/a1faad02-e22c-48d5-a708-45adeb0cbe4b)
