### PR TITLE
Small kaj changes

### DIFF
--- a/src/components/ChallengeTabHeader.vue
+++ b/src/components/ChallengeTabHeader.vue
@@ -41,14 +41,14 @@ export default {
     restartChallenge() {
       const current = Player.anyChallenge;
       if (Player.isInAnyChallenge) {
-        current.exit();
+        current.exit(true);
         current.start();
       }
     },
     exitChallenge() {
       const current = Player.anyChallenge;
       if (Player.isInAnyChallenge) {
-        current.exit();
+        current.exit(false);
       }
     },
   }

--- a/src/components/tabs/eternity-challenges/EternityChallengesTab.vue
+++ b/src/components/tabs/eternity-challenges/EternityChallengesTab.vue
@@ -16,6 +16,7 @@ export default {
       showAllChallenges: false,
       autoEC: false,
       isAutoECVisible: false,
+      hasUpgradeLock: false,
       remainingECTiers: 0,
       untilNextEC: TimeSpan.zero,
       untilAllEC: TimeSpan.zero,
@@ -25,6 +26,11 @@ export default {
   computed: {
     challenges() {
       return EternityChallenges.all;
+    },
+    upgradeLockNameText() {
+      return RealityUpgrade(12).isLockingMechanics
+        ? RealityUpgrade(12).name
+        : ImaginaryUpgrade(15).name;
     },
     nextECText() {
       return this.untilNextEC.totalMilliseconds === 0 && !this.autoEC
@@ -45,6 +51,10 @@ export default {
         .length;
       this.isAutoECVisible = Perk.autocompleteEC1.canBeApplied;
       this.autoEC = player.reality.autoEC;
+      const shouldPreventEC7 = TimeDimension(1).amount.gt(0);
+      this.hasUpgradeLock = RealityUpgrade(12).isLockingMechanics ||
+        (ImaginaryUpgrade(15).isLockingMechanics && shouldPreventEC7 &&
+          !Array.range(1, 6).some(ec => !EternityChallenge(ec).isFullyCompleted));
       const remainingCompletions = EternityChallenges.remainingCompletions;
       this.remainingECTiers = remainingCompletions;
       if (remainingCompletions !== 0) {
@@ -75,6 +85,12 @@ export default {
       class="c-challenges-tab__auto-ec-info l-challenges-tab__auto-ec-info"
     >
       <div class="l-challenges-tab__auto-ec-timers">
+        <span
+          v-if="hasUpgradeLock"
+          class="l-emphasis"
+        >
+          Auto EC is currently disabled because of the "{{ upgradeLockNameText }}" upgrade requirement lock.
+        </span>
         <span v-if="remainingECTiers > 0">
           Next Auto Eternity Challenge completion: {{ nextECText }}
         </span>
@@ -109,5 +125,8 @@ export default {
 </template>
 
 <style scoped>
-
+.l-emphasis {
+  font-weight: bold;
+  color: var(--color-bad);
+}
 </style>

--- a/src/components/ui-modes/HeaderChallengeDisplay.vue
+++ b/src/components/ui-modes/HeaderChallengeDisplay.vue
@@ -133,7 +133,7 @@ export default {
         names = { chall: toExit, normal: isEC ? "Eternity" : "Infinity" };
         clickFn = () => {
           const oldChall = Player.anyChallenge;
-          Player.anyChallenge.exit();
+          Player.anyChallenge.exit(false);
           if (player.options.retryChallenge) oldChall.requestStart();
         };
       } else {

--- a/src/core/autobuyers/big-crunch-autobuyer.js
+++ b/src/core/autobuyers/big-crunch-autobuyer.js
@@ -76,7 +76,7 @@ export class BigCrunchAutobuyerState extends UpgradeableAutobuyerState {
     return (considerMilestoneReached || EternityMilestone.autoInfinities.isReached) &&
       !EternityChallenge(4).isRunning && !EternityChallenge(12).isRunning && !Player.isInAntimatterChallenge &&
       player.auto.autobuyersOn && this.data.isActive &&
-      !Autobuyer.eternity.isActive && this.mode === AUTO_CRUNCH_MODE.TIME && this.time < 60 &&
+      !Autobuyer.eternity.isActive && this.mode === AUTO_CRUNCH_MODE.TIME && this.time <= 5 &&
       !Autobuyer.eternity.autoEternitiesAvailable();
   }
 

--- a/src/core/automator/automator-commands.js
+++ b/src/core/automator/automator-commands.js
@@ -222,25 +222,23 @@ export const AutomatorCommands = [
         { ALT: () => $.CONSUME(T.Off) },
       ]);
     },
-    validate: (ctx, V) => {
+    validate: ctx => {
       ctx.startLine = ctx.BlackHole[0].startLine;
-      if (!BlackHole(1).isUnlocked) {
-        if (Enslaved.isRunning || Pelle.isDisabled("blackhole")) {
-          V.addError(ctx.BlackHole[0], "Black Hole is disabled in your current Reality",
-            "Return to normal Reality conditions to use this command again");
-        } else {
-          V.addError(ctx.BlackHole[0], "Black Hole is not unlocked",
-            "Unlock the Black Hole in order to pause or unpause it");
-        }
-        return false;
-      }
       return true;
     },
     compile: ctx => {
       const on = Boolean(ctx.On);
       return () => {
         if (on === BlackHoles.arePaused) BlackHoles.togglePause();
-        AutomatorData.logCommandEvent(`Black Holes toggled ${ctx.On ? "ON" : "OFF"}`, ctx.startLine);
+        let blackHoleEvent;
+        if (BlackHole(1).isUnlocked) {
+          blackHoleEvent = `Black Holes toggled ${ctx.On ? "ON" : "OFF"}`;
+        } else if (Enslaved.isRunning || Pelle.isDisabled("blackhole")) {
+          blackHoleEvent = "Black Hole command ignored because BH is disabled in your current Reality";
+        } else {
+          blackHoleEvent = "Black Hole command ignored because BH is not unlocked";
+        }
+        AutomatorData.logCommandEvent(blackHoleEvent, ctx.startLine);
         return AUTOMATOR_COMMAND_STATUS.NEXT_INSTRUCTION;
       };
     },

--- a/src/core/black-hole.js
+++ b/src/core/black-hole.js
@@ -491,7 +491,7 @@ export const BlackHoles = {
     const effectsToConsider = [GAME_SPEED_EFFECT.FIXED_SPEED, GAME_SPEED_EFFECT.TIME_GLYPH,
       GAME_SPEED_EFFECT.SINGULARITY_MILESTONE, GAME_SPEED_EFFECT.NERFS];
     const speedupWithoutBlackHole = getGameSpeedupFactor(effectsToConsider);
-    const speedups = [1];
+    const speedups = [speedupWithoutBlackHole];
     effectsToConsider.push(GAME_SPEED_EFFECT.BLACK_HOLE);
     // Crucial thing: this works even if the black holes are paused, it's just that the speedups will be 1.
     for (const blackHole of this.list) {

--- a/src/core/eternity-challenge.js
+++ b/src/core/eternity-challenge.js
@@ -236,16 +236,17 @@ export class EternityChallengeState extends GameMechanicState {
       this.config.checkRestriction(this.config.restriction(completions));
   }
 
-  exit() {
+  exit(isRestarting) {
     if (Player.isInAntimatterChallenge) {
       Player.antimatterChallenge.exit();
     }
     player.challenge.eternity.current = 0;
+    if (!isRestarting) player.respec = true;
     eternity(true);
   }
 
   fail(auto = false) {
-    this.exit();
+    this.exit(false);
     let reason;
     if (auto) {
       if (this.id === 4) {

--- a/src/core/new-game.js
+++ b/src/core/new-game.js
@@ -63,6 +63,8 @@ export const NG = {
     const glyphCosmetics = JSON.stringify(player.reality.glyphs.cosmetics);
     const speedrunRecords = JSON.stringify(player.speedrun.previousRuns);
     const hasSpeedrun = player.speedrun.isUnlocked;
+    const presets = JSON.stringify(player.timestudy.presets);
+    const companions = JSON.stringify(Glyphs.allGlyphs.filter(g => g.type === "companion"));
     Modal.hideAll();
     Quote.clearAll();
     GameStorage.hardReset();
@@ -82,6 +84,10 @@ export const NG = {
     player.reality.glyphs.cosmetics = JSON.parse(glyphCosmetics);
     player.speedrun.previousRuns = JSON.parse(speedrunRecords);
     player.speedrun.isUnlocked = hasSpeedrun;
+    player.timestudy.presets = JSON.parse(presets);
+    JSON.parse(companions).forEach(g => {
+      Glyphs.addToInventory(g);
+    });
     Themes.find(Theme.currentName()).set();
     Notations.all.find(n => n.name === player.options.notation).setAsCurrent();
     ADNotations.Settings.exponentCommas.min = 10 ** player.options.notationDigits.comma;

--- a/src/core/secret-formula/eternity/eternity-milestones.js
+++ b/src/core/secret-formula/eternity/eternity-milestones.js
@@ -181,7 +181,7 @@ export const eternityMilestones = {
     },
     activeCondition: () => (player.options.offlineProgress
       ? `Must be outside of Normal/Infinity Challenges and outside of EC4 and EC12,
-        the Big Crunch Autobuyer must be turned on and set to time mode with less than ${formatInt(60)} seconds,
+        the Big Crunch Autobuyer must be turned on and set to time mode with less than ${formatInt(5)} seconds,
         and the Eternity Autobuyer must be turned off.`
       : ""),
       pelleUseless: true

--- a/src/core/secret-formula/eternity/eternity-upgrades.js
+++ b/src/core/secret-formula/eternity/eternity-upgrades.js
@@ -4,7 +4,7 @@ export const eternityUpgrades = {
   idMultEP: {
     id: 1,
     cost: 5,
-    description: () => `Infinity Dimensions multiplier based on unspent Eternity Points (x+${formatInt(1)})`,
+    description: () => `Infinity Dimension multiplier based on unspent Eternity Points (x+${formatInt(1)})`,
     effect: () => Currency.eternityPoints.value.plus(1),
     formatEffect: value => formatX(value, 2, 1)
   },
@@ -30,7 +30,7 @@ export const eternityUpgrades = {
   idMultICRecords: {
     id: 3,
     cost: 5e4,
-    description: "Infinity Dimensions multiplier based on sum of Infinity Challenge times",
+    description: "Infinity Dimension multiplier based on sum of Infinity Challenge times",
     // The cap limits this at a lower value, but we also need an explicit cap here because very old versions have
     // allowed EC12 to make all the challenge records sum to zero (causing a division by zero here)
     effect: () => DC.D2.pow(30 / Math.clampMin(Time.infinityChallengeSum.totalSeconds, 0.1)),


### PR DESCRIPTION
- Added display when Auto EC is disabled by requirement lock
- Disabled blackhole command error in cel3 and cel7
- Changed milestone 1000 requirement to 5 seconds or less
- Study tree will now automatically respec when exiting an EC
- Companion glyph and study presets now carry over when you start over
- Fixed text inconsistency
- Fixed offline progress bug