### PR TITLE
Fix Blobflakes when resizing window

### DIFF
--- a/src/components/BlobSnowflake.vue
+++ b/src/components/BlobSnowflake.vue
@@ -94,7 +94,7 @@ export default {
       }
     },
     onresize() {
-      // Calling this.beforeMounted doesn't work here
+      // Calling this.beforeDestroy doesn't work here
       for (const tween of this.tweens) {
         TWEEN.remove(tween);
       }

--- a/src/components/BlobSnowflake.vue
+++ b/src/components/BlobSnowflake.vue
@@ -11,11 +11,13 @@ export default {
   },
   mounted() {
     this.fly();
+    window.addEventListener("resize", this.onresize);
   },
   beforeDestroy() {
     for (const tween of this.tweens) {
       TWEEN.remove(tween);
     }
+    window.removeEventListener("resize", this.onresize);
   },
   methods: {
     fly() {
@@ -91,6 +93,13 @@ export default {
           : SNOW[Math.floor(Math.random() * SNOW.length)];
       }
     },
+    onresize() {
+      // Calling this.beforeMounted doesn't work here
+      for (const tween of this.tweens) {
+        TWEEN.remove(tween);
+      }
+      this.fly();
+    }
   }
 };
 </script>


### PR DESCRIPTION
When you resize the window, blobflakes will keep on spawning in that one place and not the entire window. This PR is an attempt to fix it.

This is how it used to look (image taken by mechapanda on the Discord server):
![image](https://github.com/IvarK/AntimatterDimensionsSourceCode/assets/100215778/cf063229-0b28-48c1-a7a2-7e0e844ea626)

This is how it acts on this branch:
https://github.com/IvarK/AntimatterDimensionsSourceCode/assets/100215778/3e3b822e-58ee-475a-a0a9-67dd1be18c7f

This does cause flickering when resizing sometimes, but I'm not sure how to solve that.