### PR TITLE
Make ICs effects display when the challenge isn't completed

### DIFF
--- a/src/components/tabs/infinity-challenges/InfinityChallengeBox.vue
+++ b/src/components/tabs/infinity-challenges/InfinityChallengeBox.vue
@@ -66,7 +66,6 @@ export default {
           title="Reward:"
         />
         <EffectDisplay
-          v-if="isCompleted"
           :config="config.reward"
         />
       </div>


### PR DESCRIPTION
This makes the effect of ICs even when the challenge isn't completed. This is the default behaviour of other mechanics, ie. IUs and Achievements.