### PR TITLE
Modify IDs and TDs to hopefully not shrink text as much

### DIFF
--- a/src/components/tabs/infinity-dimensions/ClassicInfinityDimensionRow.vue
+++ b/src/components/tabs/infinity-dimensions/ClassicInfinityDimensionRow.vue
@@ -73,7 +73,7 @@ export default {
         this.hasPrevTier;
     },
     showCostTitle() {
-      return this.cost.exponent < 1e4;
+      return this.cost.exponent < 1e5;
     }
   },
   watch: {

--- a/src/components/tabs/infinity-dimensions/ClassicInfinityDimensionRow.vue
+++ b/src/components/tabs/infinity-dimensions/ClassicInfinityDimensionRow.vue
@@ -73,7 +73,7 @@ export default {
         this.hasPrevTier;
     },
     showCostTitle() {
-      return this.cost.exponent < 1e6;
+      return this.cost.exponent < 1e4;
     }
   },
   watch: {

--- a/src/components/tabs/infinity-dimensions/ModernInfinityDimensionRow.vue
+++ b/src/components/tabs/infinity-dimensions/ModernInfinityDimensionRow.vue
@@ -70,7 +70,7 @@ export default {
         this.hasPrevTier;
     },
     showCostTitle() {
-      return this.cost.exponent < 1e4;
+      return this.cost.exponent < 1e5;
     }
   },
   watch: {

--- a/src/components/tabs/infinity-dimensions/ModernInfinityDimensionRow.vue
+++ b/src/components/tabs/infinity-dimensions/ModernInfinityDimensionRow.vue
@@ -58,7 +58,7 @@ export default {
       return `Reach ${formatPostBreak(InfinityDimension(this.tier).amRequirement)} AM`;
     },
     hasLongText() {
-      return this.costDisplay.length > 15;
+      return this.costDisplay.length > 20;
     },
     capTooltip() {
       if (this.enslavedRunning) return `Nameless prevents the purchase of more than ${format(10)} Infinity Dimensions`;
@@ -70,7 +70,7 @@ export default {
         this.hasPrevTier;
     },
     showCostTitle() {
-      return this.cost.exponent < 1e6;
+      return this.cost.exponent < 1e4;
     }
   },
   watch: {

--- a/src/components/tabs/time-dimensions/ClassicTimeDimensionRow.vue
+++ b/src/components/tabs/time-dimensions/ClassicTimeDimensionRow.vue
@@ -68,7 +68,7 @@ export default {
       return this.buttonContents.length > 20;
     },
     showCostTitle() {
-      return this.cost.exponent < 1e6;
+      return this.cost.exponent < 1e1;
     },
     timeEstimate() {
       if (!this.showTTCost || this.ttGen.eq(0)) return "";

--- a/src/components/tabs/time-dimensions/ClassicTimeDimensionRow.vue
+++ b/src/components/tabs/time-dimensions/ClassicTimeDimensionRow.vue
@@ -68,7 +68,7 @@ export default {
       return this.buttonContents.length > 20;
     },
     showCostTitle() {
-      return this.cost.exponent < 1e1;
+      return this.cost.exponent < 1e5;
     },
     timeEstimate() {
       if (!this.showTTCost || this.ttGen.eq(0)) return "";

--- a/src/components/tabs/time-dimensions/ModernTimeDimensionRow.vue
+++ b/src/components/tabs/time-dimensions/ModernTimeDimensionRow.vue
@@ -70,7 +70,7 @@ export default {
       return this.buttonContents.length > 20;
     },
     showCostTitle() {
-      return this.cost.exponent < 1e1;
+      return this.cost.exponent < 1e5;
     },
     timeEstimate() {
       if (!this.showTTCost || this.ttGen.eq(0)) return "";

--- a/src/components/tabs/time-dimensions/ModernTimeDimensionRow.vue
+++ b/src/components/tabs/time-dimensions/ModernTimeDimensionRow.vue
@@ -67,10 +67,10 @@ export default {
       return this.isCapped ? "Capped" : `${this.showCostTitle ? "Cost: " : ""}${format(this.cost, 2)} EP`;
     },
     hasLongText() {
-      return this.buttonContents.length > 15;
+      return this.buttonContents.length > 20;
     },
     showCostTitle() {
-      return this.cost.exponent < 1e6;
+      return this.cost.exponent < 1e1;
     },
     timeEstimate() {
       if (!this.showTTCost || this.ttGen.eq(0)) return "";


### PR DESCRIPTION
I honestly find the fact that the TD buttons' text shrinks almost instantly (when they reach a cost bigger than e10 EP), where the button definitely has space to fit the text. This PR is an attempt to not make the text shrink as much and as early on both TDs and IDs.