### PR TITLE
Remove everything related to Sacrifice in the IDs tab

### DIFF
--- a/src/components/tabs/infinity-dimensions/ModernInfinityDimensionsTab.vue
+++ b/src/components/tabs/infinity-dimensions/ModernInfinityDimensionsTab.vue
@@ -32,12 +32,6 @@ export default {
     };
   },
   computed: {
-    sacrificeBoostDisplay() {
-      return formatX(this.sacrificeBoost, 2, 2);
-    },
-    sacrificeTooltip() {
-      return `Boosts 8th Antimatter Dimension by ${this.sacrificeBoostDisplay}`;
-    },
     tesseractCountString() {
       const extra = this.extraTesseracts > 0 ? ` + ${format(this.extraTesseracts, 2, 2)}` : "";
       return `${formatInt(this.boughtTesseracts)}${extra}`;


### PR DESCRIPTION
I think these were left in while copying the AD tab. They are not used anywhere so they are safe to remove.