### PR TITLE
Add a screen reader mode

### DIFF
--- a/src/components/tabs/options-visual/OptionsVisualTab.vue
+++ b/src/components/tabs/options-visual/OptionsVisualTab.vue
@@ -41,6 +41,9 @@ export default {
     },
     UILabel() {
       return `UI: ${this.$viewModel.newUI ? "Modern" : "Classic"}`;
+    },
+    SRModeLabel() {
+      return `Screen reader mode: ${this.$viewModel.srMode ? "On" : "Off"}`;
     }
   },
   watch: {
@@ -71,6 +74,12 @@ export default {
           onclick="GameOptions.toggleUI()"
         >
           {{ UILabel }}
+        </OptionsButton>
+        <OptionsButton
+          class="o-primary-btn--option_font-large"
+          onclick="GameOptions.toggleSRMode()"
+        >
+          {{ SRModeLabel }}
         </OptionsButton>
         <UpdateRateSlider />
         <OptionsButton

--- a/src/core/options.js
+++ b/src/core/options.js
@@ -24,6 +24,13 @@ export class GameOptions {
     GameStorage.save();
   }
 
+  static toggleSRMode() {
+    player.options.srMode = !player.options.srMode;
+    ui.view.srMode = player.options.srMode;
+    GameStorage.save();
+    if (player.options.srMode) GameUI.notify.info("Screen reader mode enabled. Some tricks to using this mode can now be found in certain sections of the how to play modal (open by pressing H or clicking on the question mark near the bottom of the page). You can also try setting the UI mode to classic, and don't forget to turn off animations if they slow things down.");
+  }
+
   static cloudSave() {
     Cloud.saveCheck(true);
   }

--- a/src/core/options.js
+++ b/src/core/options.js
@@ -28,7 +28,13 @@ export class GameOptions {
     player.options.srMode = !player.options.srMode;
     ui.view.srMode = player.options.srMode;
     GameStorage.save();
-    if (player.options.srMode) GameUI.notify.info("Screen reader mode enabled. Some tricks to using this mode can now be found in certain sections of the how to play modal (open by pressing H or clicking on the question mark near the bottom of the page). You can also try setting the UI mode to classic, and don't forget to turn off animations if they slow things down.");
+    if (player.options.srMode) {
+      GameUI.notify.info(`Screen reader mode enabled.
+      Some tricks to using this mode can now be found in certain sections of the how to play
+      modal (open by pressing H or clicking on the question mark near the bottom of the page).
+      You can also try setting the UI mode to classic, and
+      don't forget to turn off animations if they slow things down.`);
+    }
   }
 
   static cloudSave() {

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -791,6 +791,7 @@ window.player = {
     themeModern: "Normal",
     updateRate: 33,
     newUI: true,
+    srMode: false,
     offlineProgress: true,
     loadBackupWithoutOffline: false,
     automaticTabSwitching: true,

--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -470,6 +470,7 @@ export const GameStorage = {
 
     ui.view.news = player.options.news.enabled;
     ui.view.newUI = player.options.newUI;
+    ui.view.srMode = player.options.srMode;
     ui.view.tutorialState = player.tutorialState;
     ui.view.tutorialActive = player.tutorialActive;
 

--- a/src/core/ui.init.js
+++ b/src/core/ui.init.js
@@ -45,6 +45,7 @@ export const state = {
     tab: "dimensions",
     subtab: "antimatter",
     newUI: false,
+    srMode: false,
     news: false,
     initialized: false,
     tutorialState: 0,


### PR DESCRIPTION
This is an option under the visual subtab that anyone with a screen reader can turn on and persists across saves.

Future pull requests by me will use ```
v-if="$viewModel.srMode"
```
to swap out inaccessible parts of the UI with accessible ones on a case-by-case basis, since tabs often have both accessible and inaccessible elements.
