### PR TITLE
Implemented buy 10 toggle based on issue #1886

### DIFF
--- a/src/components/tabs/autobuyers/AutobuyerToggles.vue
+++ b/src/components/tabs/autobuyers/AutobuyerToggles.vue
@@ -36,9 +36,9 @@ export default {
       this.autobuyersOn = player.auto.autobuyersOn;
       this.showContinuum = Laitela.isUnlocked;
       this.disableContinuum = player.auto.disableContinuum;
-      this.allAutobuyersDisabled = Autobuyers.unlocked.every((autobuyer) => !autobuyer.isActive);
+      this.allAutobuyersDisabled = Autobuyers.unlocked.every(autobuyer => !autobuyer.isActive);
       this.antimatterAutobuyersBuyMax = Autobuyer.antimatterDimension.zeroIndexed.every(
-        (autobuyer) => autobuyer.mode === AUTOBUYER_MODE.BUY_10
+        autobuyer => autobuyer.mode === AUTOBUYER_MODE.BUY_10
       );
     },
     toggleAllAutobuyers() {
@@ -69,7 +69,10 @@ export default {
     >
       {{ allAutobuyersDisabled ? "Enable" : "Disable" }} all autobuyers
     </PrimaryButton>
-    <PrimaryButton class="o-primary-btn--subtab-option" @click="toggleAntimatterSingles()">
+    <PrimaryButton
+      class="o-primary-btn--subtab-option"
+      @click="toggleAntimatterSingles()"
+    >
       Set AD autobuyers to buy {{ antimatterAutobuyersBuyMax ? "singles" : "max" }}
     </PrimaryButton>
     <span v-if="isDoomed">

--- a/src/components/tabs/autobuyers/AutobuyerToggles.vue
+++ b/src/components/tabs/autobuyers/AutobuyerToggles.vue
@@ -6,7 +6,7 @@ export default {
   name: "AutobuyerToggles",
   components: {
     PrimaryButton,
-    PrimaryToggleButton
+    PrimaryToggleButton,
   },
   data() {
     return {
@@ -14,7 +14,8 @@ export default {
       autobuyersOn: false,
       showContinuum: false,
       disableContinuum: false,
-      allAutobuyersDisabled: false
+      allAutobuyersDisabled: false,
+      antimatterAutobuyersBuyMax: false,
     };
   },
   watch: {
@@ -35,14 +36,22 @@ export default {
       this.autobuyersOn = player.auto.autobuyersOn;
       this.showContinuum = Laitela.isUnlocked;
       this.disableContinuum = player.auto.disableContinuum;
-      this.allAutobuyersDisabled = Autobuyers.unlocked.every(autobuyer => !autobuyer.isActive);
+      this.allAutobuyersDisabled = Autobuyers.unlocked.every((autobuyer) => !autobuyer.isActive);
+      this.antimatterAutobuyersBuyMax = Autobuyer.antimatterDimension.zeroIndexed.every(
+        (autobuyer) => autobuyer.mode === AUTOBUYER_MODE.BUY_10
+      );
     },
     toggleAllAutobuyers() {
       for (const autobuyer of Autobuyers.unlocked) {
         autobuyer.isActive = this.allAutobuyersDisabled;
       }
-    }
-  }
+    },
+    toggleAntimatterSingles() {
+      for (const autobuyer of Autobuyer.antimatterDimension.zeroIndexed) {
+        autobuyer.mode = this.antimatterAutobuyersBuyMax ? AUTOBUYER_MODE.BUY_SINGLE : AUTOBUYER_MODE.BUY_10;
+      }
+    },
+  },
 };
 </script>
 
@@ -59,6 +68,9 @@ export default {
       @click="toggleAllAutobuyers()"
     >
       {{ allAutobuyersDisabled ? "Enable" : "Disable" }} all autobuyers
+    </PrimaryButton>
+    <PrimaryButton class="o-primary-btn--subtab-option" @click="toggleAntimatterSingles()">
+      Set AD autobuyers to buy {{ antimatterAutobuyersBuyMax ? "singles" : "max" }}
     </PrimaryButton>
     <span v-if="isDoomed">
       <PrimaryButton


### PR DESCRIPTION
Created an implementation based of feature in issue #1886. The behavior is as follows:

- If all ADs are on buy max it the button will change them to singles
- If all ADs are on singles it the button will change them to buy max
- If one or more ADs are on singles, it will change the single ones to max

The button to toggle these is next to 'Disable all autobuyers'

P.S.: This is my first PR ever so please comment if I've done anything wrong