### PR TITLE
Fix backup import from file

### DIFF
--- a/src/components/modals/options/BackupWindowModal.vue
+++ b/src/components/modals/options/BackupWindowModal.vue
@@ -99,7 +99,7 @@ export default {
         >
           Export as file
         </PrimaryButton>
-        <PrimaryButton class="o-btn-file-ops">
+        <PrimaryButton class="o-btn-file-ops c-file-import-button">
           <input
             class="c-file-import"
             type="file"

--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -392,7 +392,7 @@ export const GameStorage = {
       const id = Number(backupKey);
       const storageKey = this.backupDataKey(this.currentSlot, id);
       localStorage.setItem(storageKey, GameSaveSerializer.serialize(backupData[backupKey]));
-      this.backupTimeData[id] = {
+      this.lastBackupTimes[id] = {
         backupTimer: backupData.time[id].backupTimer,
         date: backupData.time[id].date,
       };


### PR DESCRIPTION
I came across a bug with in the Backup Saves modal. Basically, the "Import Saves" button was not working. I asked Claude to diagnose the issue, and Claude found to problems: first, there was a CSS issue that led to the file selection window not being opened; and there was a second independent issue, that led to game state not being updated, even after the file was loaded.

The fix is simple and I verified locally that it works.

For reference, below is the analysis done by Claude: The "Import from file" button in the Automatic Backup Saves modal was broken in two independent ways:

1. UI: the button never opened a file picker. The invisible `.c-file-import` input is `position: absolute` and relies on a `position: relative` wrapper (`.c-file-import-button`) to be anchored over the button, exactly as the working import in OptionsSavingTab.vue does. The backup modal's PrimaryButton omitted that class, so the invisible input was positioned elsewhere and clicks on the button never reached it (and the `<label for="file">` has no matching element). Add `c-file-import-button` to anchor the input over the button.

2. Logic: importBackupsFromFile wrote the per-slot times to `this.backupTimeData`, a property that exists nowhere else; the field read by the modal, resetBackupTimer(), and the backup logic is `this.lastBackupTimes`. The imported backups were persisted to localStorage but the in-memory state/UI never refreshed until a reload. Write to `this.lastBackupTimes` instead.